### PR TITLE
Standardise frontmatter order

### DIFF
--- a/src/content/articles/1707097478847-personal-crms-clay-earth-is-not-what-i-need.md
+++ b/src/content/articles/1707097478847-personal-crms-clay-earth-is-not-what-i-need.md
@@ -1,10 +1,10 @@
 ---
-draft: true
 title: Why Personal CRMs Don't Work for Remote Work Consultants
 slug: personal-crms-clay-earth-is-not-what-i-need
+draft: true
+description: A consultant's honest take on why personal CRMs fail for relationship-building. Alternative approaches to managing professional networks by remote work expert Danny Smith.
 pubDate: 2024-02-05
 updatedDate: 2024-02-05
-description: A consultant's honest take on why personal CRMs fail for relationship-building. Alternative approaches to managing professional networks by remote work expert Danny Smith.
 ---
 
 I paid a 12-month subscription for a Personal CRM called [Clay](https://clay.earth/) because I need help "mamaging my personal and professional relationships". It's not bad software. BUT...

--- a/src/content/articles/2012-06-05-a-simpler-responsive-grid.mdx
+++ b/src/content/articles/2012-06-05-a-simpler-responsive-grid.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'A Simpler Responsive Grid'
-pubDate: 2012-06-05
 slug: a-simpler-responsive-grid
 draft: false
 description: 'A simple percentage-based CSS grid system that makes responsive design math easy'
+pubDate: 2012-06-05
 tags: ['css', 'responsive', 'grid', 'design']
 ---
 

--- a/src/content/articles/2013-01-21-what-is-good-design.md
+++ b/src/content/articles/2013-01-21-what-is-good-design.md
@@ -1,9 +1,9 @@
 ---
 title: 'What is Good Design?'
-pubDate: 2013-01-21
 slug: what-is-good-design
 draft: false
 description: 'Exploring good design principles through the lens of the UK Government Digital Service website'
+pubDate: 2013-01-21
 tags: ['design', 'government', 'typography', 'web']
 ---
 

--- a/src/content/articles/2013-06-28-mod-email-subjects-with-applescript.mdx
+++ b/src/content/articles/2013-06-28-mod-email-subjects-with-applescript.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'MoD Email Subjects with AppleScript'
-pubDate: 2013-06-28
 slug: mod-email-subject-lines-with-applescript-osx
 draft: false
 description: 'Automating military email subject line formatting with AppleScript for Mac Mail'
+pubDate: 2013-06-28
 tags: ['applescript', 'automation', 'email', 'military', 'productivity']
 ---
 
@@ -14,7 +14,6 @@ import modEmailImage from '@assets/articles/13-1-MoD-File-Names-Explained.png';
 The work I do with the RAF and Army requires me to send emails with the date and security classification included, like this: "20130628-The Subject-U".
 
 <Image src={modEmailImage} alt="MoD File Names Explained" />
-
 
 I must do this at least 30 times a day, and earlier on I was that fed up with copy/pasting dates that I decided to write a script to do it for me. I did try this once before, but Mail.app's API wasn't very robust at the time and the action relied upon simulating keypresses which wasn't exactly reliable.
 

--- a/src/content/articles/2013-10-02-new-job-new-website.md
+++ b/src/content/articles/2013-10-02-new-job-new-website.md
@@ -1,9 +1,9 @@
 ---
 title: 'New Job, New Website'
-pubDate: 2013-10-02
 slug: new-job-new-website
 draft: false
 description: 'Transitioning from designer to Ruby developer and building a custom Sinatra-based website'
+pubDate: 2013-10-02
 tags: ['ruby', 'sinatra', 'web development', 'career', 'personal']
 ---
 

--- a/src/content/articles/2013-10-08-rvm-to-rbenv.md
+++ b/src/content/articles/2013-10-08-rvm-to-rbenv.md
@@ -1,9 +1,9 @@
 ---
 title: 'From RVM to rbenv'
-pubDate: 2013-10-08
 slug: rvm-to-rbenv
 draft: false
 description: 'Switching from RVM to rbenv for simpler Ruby version and gem management'
+pubDate: 2013-10-08
 tags: ['ruby', 'rbenv', 'rvm', 'development', 'tools']
 ---
 

--- a/src/content/articles/2014-04-20-a-pretty-readability-archive-with-ruby-and-css.md
+++ b/src/content/articles/2014-04-20-a-pretty-readability-archive-with-ruby-and-css.md
@@ -1,9 +1,9 @@
 ---
 title: 'A Pretty Readability Archive with Ruby and CSS'
-pubDate: 2014-04-20
 slug: a-pretty-readability-archive-with-ruby-and-css
 draft: false
 description: 'Building a visual bookmarks display using the Readability API, Ruby, and CSS 3D transforms'
+pubDate: 2014-04-20
 tags: ['ruby', 'css', 'api', 'readability', 'sinatra', 'design']
 ---
 

--- a/src/content/articles/2014-05-04-controlling-the-rag-with-redcarpet.md
+++ b/src/content/articles/2014-05-04-controlling-the-rag-with-redcarpet.md
@@ -1,9 +1,9 @@
 ---
 title: 'Controlling the Rag with Redcarpet'
-pubDate: 2014-05-04
 slug: controlling-the-rag-with-redcarpet
 draft: false
 description: 'Improving web typography by preventing orphans and controlling line breaks with custom Redcarpet renderer'
+pubDate: 2014-05-04
 tags: ['typography', 'ruby', 'redcarpet', 'markdown', 'web design']
 ---
 

--- a/src/content/articles/2014-05-04-on-sass-and-other-css-preprocessors.md
+++ b/src/content/articles/2014-05-04-on-sass-and-other-css-preprocessors.md
@@ -1,6 +1,6 @@
 ---
 title: 'On Sass and Other CSS Preprocessors'
-redirectURL: 'https://medium.com/@dannysmith/'
-platform: medium
 pubDate: 2014-05-04
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/'
 ---

--- a/src/content/articles/2015-02-24-agile-feedback-loops-by-danny-smith.md
+++ b/src/content/articles/2015-02-24-agile-feedback-loops-by-danny-smith.md
@@ -1,6 +1,6 @@
 ---
 title: 'Agile Feedback Loops'
-redirectURL: 'https://medium.com/@dannysmith/agile-feedback-loops-by-danny-smith-64f6f14894bc'
-platform: medium
 pubDate: 2015-02-24
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/agile-feedback-loops-by-danny-smith-64f6f14894bc'
 ---

--- a/src/content/articles/2015-02-24-writing-testable-code.md
+++ b/src/content/articles/2015-02-24-writing-testable-code.md
@@ -1,6 +1,6 @@
 ---
 title: 'Writing Testable Code'
-redirectURL: 'https://medium.com/@dannysmith/writing-testable-code-791475659254'
-platform: medium
 pubDate: 2015-02-24
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/writing-testable-code-791475659254'
 ---

--- a/src/content/articles/2015-02-26-blogging-with-evernote-and-ruby.md
+++ b/src/content/articles/2015-02-26-blogging-with-evernote-and-ruby.md
@@ -1,6 +1,6 @@
 ---
 title: 'Blogging with Evernote and Ruby'
-redirectURL: 'https://medium.com/@dannysmith/blogging-with-evernote-and-ruby-212dc415c4ec'
-platform: medium
 pubDate: 2015-02-26
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/blogging-with-evernote-and-ruby-212dc415c4ec'
 ---

--- a/src/content/articles/2015-02-26-replacing-bash-with-zsh-on-osx.md
+++ b/src/content/articles/2015-02-26-replacing-bash-with-zsh-on-osx.md
@@ -1,6 +1,6 @@
 ---
 title: 'Replacing Bash with ZSH on OSX'
-redirectURL: 'https://medium.com/@dannysmith/replacing-bash-with-zsh-on-osx-9d88d9d7eaa5'
-platform: medium
 pubDate: 2015-02-26
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/replacing-bash-with-zsh-on-osx-9d88d9d7eaa5'
 ---

--- a/src/content/articles/2015-03-17-delivering-business-value-with-kanban-and-validated-learning.md
+++ b/src/content/articles/2015-03-17-delivering-business-value-with-kanban-and-validated-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'Delivering Business Value with Kanban and Validated Learning'
-redirectURL: 'https://medium.com/@dannysmith/delivering-business-value-with-kanban-and-validated-learning-55749daffecc'
-platform: medium
 pubDate: 2015-03-17
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/delivering-business-value-with-kanban-and-validated-learning-55749daffecc'
 ---

--- a/src/content/articles/2015-07-22-the-changing-face-of-software-testing.md
+++ b/src/content/articles/2015-07-22-the-changing-face-of-software-testing.md
@@ -1,6 +1,6 @@
 ---
 title: 'The Changing Face of Software Testing'
-redirectURL: 'https://medium.com/@dannysmith/the-changing-face-of-software-testing-f9609c5e16bc'
-platform: medium
 pubDate: 2015-07-22
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/the-changing-face-of-software-testing-f9609c5e16bc'
 ---

--- a/src/content/articles/2015-07-25-the-psychoactive-substances-bill-2015.md
+++ b/src/content/articles/2015-07-25-the-psychoactive-substances-bill-2015.md
@@ -1,6 +1,6 @@
 ---
 title: 'The Psychoactive Substances Bill 2015'
-redirectURL: 'https://medium.com/@dannysmith/the-psychoactive-substances-bill-2015-293c7c1b04d3'
-platform: medium
 pubDate: 2015-07-25
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/the-psychoactive-substances-bill-2015-293c7c1b04d3'
 ---

--- a/src/content/articles/2015-08-29-getting-things-done.md
+++ b/src/content/articles/2015-08-29-getting-things-done.md
@@ -1,6 +1,6 @@
 ---
 title: 'Getting Things Done'
-redirectURL: 'https://medium.com/@dannysmith/getting-things-done-92f6ad51faf9'
-platform: medium
 pubDate: 2015-08-29
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/getting-things-done-92f6ad51faf9'
 ---

--- a/src/content/articles/2015-10-26-evaluating-training-and-learning.md
+++ b/src/content/articles/2015-10-26-evaluating-training-and-learning.md
@@ -1,6 +1,6 @@
 ---
 title: 'Evaluating Training and Learning'
-redirectURL: 'https://medium.com/@dannysmith/evaluating-training-and-learning-a19ff80a9eac'
-platform: medium
 pubDate: 2015-10-26
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/evaluating-training-and-learning-a19ff80a9eac'
 ---

--- a/src/content/articles/2015-11-03-my-students-have-forgotten-how-to-be-curious.md
+++ b/src/content/articles/2015-11-03-my-students-have-forgotten-how-to-be-curious.md
@@ -1,6 +1,6 @@
 ---
 title: 'My Students have Forgotten How to be Curious'
-redirectURL: 'https://medium.com/@dannysmith/my-students-have-forgotten-how-to-be-curious-84980040dfcb'
-platform: medium
 pubDate: 2015-11-03
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/my-students-have-forgotten-how-to-be-curious-84980040dfcb'
 ---

--- a/src/content/articles/2015-12-18-effective-meetings.md
+++ b/src/content/articles/2015-12-18-effective-meetings.md
@@ -1,6 +1,6 @@
 ---
 title: 'Effective Meetings'
-redirectURL: 'https://medium.com/@dannysmith/effective-meetings-4eb86ab5f8e8'
-platform: medium
 pubDate: 2015-12-18
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/effective-meetings-4eb86ab5f8e8'
 ---

--- a/src/content/articles/2016-01-04-collaborating-on-a-project.md
+++ b/src/content/articles/2016-01-04-collaborating-on-a-project.md
@@ -1,6 +1,6 @@
 ---
 title: 'Collaborating on a Project'
-redirectURL: 'https://medium.com/@dannysmith/collaborating-on-a-project-be707e4a7c1d'
-platform: medium
 pubDate: 2016-01-04
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/collaborating-on-a-project-be707e4a7c1d'
 ---

--- a/src/content/articles/2016-02-20-automating-and-outsourcing.md
+++ b/src/content/articles/2016-02-20-automating-and-outsourcing.md
@@ -1,6 +1,6 @@
 ---
 title: 'Automating and Outsourcing'
-redirectURL: 'https://medium.com/@dannysmith/automating-and-outsourcing-b37e5f4d0207'
-platform: medium
 pubDate: 2016-02-20
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/automating-and-outsourcing-b37e5f4d0207'
 ---

--- a/src/content/articles/2016-02-25-why-do-i-teach.md
+++ b/src/content/articles/2016-02-25-why-do-i-teach.md
@@ -1,6 +1,6 @@
 ---
 title: 'Why do I teach?'
-redirectURL: 'https://medium.com/@dannysmith/why-do-i-teach-c135b437573b'
-platform: medium
 pubDate: 2016-02-25
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/why-do-i-teach-c135b437573b'
 ---

--- a/src/content/articles/2016-03-02-finding-a-good-colour-palette-through-exploration.md
+++ b/src/content/articles/2016-03-02-finding-a-good-colour-palette-through-exploration.md
@@ -1,6 +1,6 @@
 ---
 title: 'Finding a Good Colour Palette through Exploration'
-redirectURL: 'https://medium.com/@dannysmith/finding-a-good-colour-palette-through-exploration-b90abde88a1c'
-platform: medium
 pubDate: 2016-03-02
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/finding-a-good-colour-palette-through-exploration-b90abde88a1c'
 ---

--- a/src/content/articles/2016-03-06-a-standard-software-toolset-for-business.md
+++ b/src/content/articles/2016-03-06-a-standard-software-toolset-for-business.md
@@ -1,6 +1,6 @@
 ---
 title: 'A Standard Software Toolset for Business?'
-redirectURL: 'https://medium.com/@dannysmith/a-standard-software-toolset-for-business-9e5b27d4dbf1'
-platform: medium
 pubDate: 2016-03-06
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/a-standard-software-toolset-for-business-9e5b27d4dbf1'
 ---

--- a/src/content/articles/2016-03-10-slack-for-enterprise.md
+++ b/src/content/articles/2016-03-10-slack-for-enterprise.md
@@ -1,6 +1,6 @@
 ---
 title: 'Slack for Enterprise'
-redirectURL: 'https://medium.com/@dannysmith/slack-for-enterprise-d60554c5ea19'
-platform: medium
 pubDate: 2016-03-10
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/slack-for-enterprise-d60554c5ea19'
 ---

--- a/src/content/articles/2016-04-23-good-slide-design.md
+++ b/src/content/articles/2016-04-23-good-slide-design.md
@@ -1,6 +1,6 @@
 ---
 title: 'Good Slide Design'
-redirectURL: 'https://medium.com/@dannysmith/good-slide-design-a95a44c3abc2'
-platform: medium
 pubDate: 2016-04-23
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/good-slide-design-a95a44c3abc2'
 ---

--- a/src/content/articles/2016-06-30-agile-adoption-patterns.md
+++ b/src/content/articles/2016-06-30-agile-adoption-patterns.md
@@ -1,6 +1,6 @@
 ---
 title: 'Agile Adoption Patterns'
-redirectURL: 'https://medium.com/@dannysmith/agile-adoption-patterns-724fb921945f'
-platform: medium
 pubDate: 2016-06-30
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/agile-adoption-patterns-724fb921945f'
 ---

--- a/src/content/articles/2016-10-24-digitalocean-dnsimple-and-terraform-a-very-short-introduction.md
+++ b/src/content/articles/2016-10-24-digitalocean-dnsimple-and-terraform-a-very-short-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: 'DigitalOcean, DNSimple and Terraform: A very short introduction.'
-redirectURL: 'https://medium.com/@dannysmith/digitalocean-dnsimple-and-terraform-a-very-short-introduction-38e84990bbf3'
-platform: medium
 pubDate: 2016-10-24
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/digitalocean-dnsimple-and-terraform-a-very-short-introduction-38e84990bbf3'
 ---

--- a/src/content/articles/2017-05-18-six-awesome-services-i-discovered-last-year.md
+++ b/src/content/articles/2017-05-18-six-awesome-services-i-discovered-last-year.md
@@ -1,6 +1,6 @@
 ---
 title: 'Six awesome services I discovered last year'
-redirectURL: 'https://medium.com/@dannysmith/six-awesome-services-i-discovered-last-year-a0bbb8886cda'
-platform: medium
 pubDate: 2017-05-18
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/six-awesome-services-i-discovered-last-year-a0bbb8886cda'
 ---

--- a/src/content/articles/2017-06-19-where-are-the-good-mobile-networks.md
+++ b/src/content/articles/2017-06-19-where-are-the-good-mobile-networks.md
@@ -1,6 +1,6 @@
 ---
 title: 'Where are the good Mobile Networks?'
-redirectURL: 'https://medium.com/@dannysmith/where-are-the-good-mobile-networks-268aed39813f'
-platform: medium
 pubDate: 2017-06-19
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/where-are-the-good-mobile-networks-268aed39813f'
 ---

--- a/src/content/articles/2017-11-26-add-starred-slack-messages-to-things-3.md
+++ b/src/content/articles/2017-11-26-add-starred-slack-messages-to-things-3.md
@@ -1,6 +1,6 @@
 ---
 title: 'Add Starred Slack Messages to Things 3'
-redirectURL: 'https://medium.com/@dannysmith/add-starred-slack-messages-to-things-3-877d8e974f21'
-platform: medium
 pubDate: 2017-11-26
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/add-starred-slack-messages-to-things-3-877d8e974f21'
 ---

--- a/src/content/articles/2017-12-19-synchronising-git-merges-with-slack.md
+++ b/src/content/articles/2017-12-19-synchronising-git-merges-with-slack.md
@@ -1,6 +1,6 @@
 ---
 title: 'Synchronising Git Merges with Slack'
-redirectURL: 'https://medium.com/@dannysmith/synchronising-git-merges-with-slack-d905f7cbd55c'
-platform: medium
 pubDate: 2017-12-19
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/synchronising-git-merges-with-slack-d905f7cbd55c'
 ---

--- a/src/content/articles/2017-12-19-the-definition-of-done-what-does-done-actually-mean.md
+++ b/src/content/articles/2017-12-19-the-definition-of-done-what-does-done-actually-mean.md
@@ -1,6 +1,6 @@
 ---
 title: 'The Definition of Done: What does “done” actually mean?'
-redirectURL: 'https://medium.com/@dannysmith/the-definition-of-done-what-does-done-actually-mean-ef1e5520e153'
-platform: medium
 pubDate: 2017-12-19
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/the-definition-of-done-what-does-done-actually-mean-ef1e5520e153'
 ---

--- a/src/content/articles/2018-04-02-little-things.md
+++ b/src/content/articles/2018-04-02-little-things.md
@@ -1,6 +1,6 @@
 ---
 title: 'Little Things'
-redirectURL: 'https://medium.com/@dannysmith/little-things-c4b8fdcdc68c'
-platform: medium
 pubDate: 2018-04-02
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/little-things-c4b8fdcdc68c'
 ---

--- a/src/content/articles/2018-04-12-little-thing-1-how-do-rspec-matchers-work.md
+++ b/src/content/articles/2018-04-12-little-thing-1-how-do-rspec-matchers-work.md
@@ -1,6 +1,6 @@
 ---
 title: 'Little Thing #1 — How do RSpec Matchers Work?'
-redirectURL: 'https://medium.com/@dannysmith/little-thing-1-how-do-rspec-matchers-work-fcba96d82aba'
-platform: medium
 pubDate: 2018-04-12
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/little-thing-1-how-do-rspec-matchers-work-fcba96d82aba'
 ---

--- a/src/content/articles/2018-08-09-little-thing-2-speeding-up-zsh.md
+++ b/src/content/articles/2018-08-09-little-thing-2-speeding-up-zsh.md
@@ -1,6 +1,6 @@
 ---
 title: 'Little Thing #2 — Speeding up ZSH'
-redirectURL: 'https://medium.com/@dannysmith/little-thing-2-speeding-up-zsh-f1860390f92'
-platform: medium
 pubDate: 2018-08-09
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/little-thing-2-speeding-up-zsh-f1860390f92'
 ---

--- a/src/content/articles/2018-11-05-little-thing-value-objects-in-ruby.md
+++ b/src/content/articles/2018-11-05-little-thing-value-objects-in-ruby.md
@@ -1,6 +1,6 @@
 ---
 title: 'Little Thing — Value Objects in Ruby'
-redirectURL: 'https://medium.com/@dannysmith/little-thing-value-objects-in-ruby-c4745aeb9c07'
-platform: medium
 pubDate: 2018-11-05
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/little-thing-value-objects-in-ruby-c4745aeb9c07'
 ---

--- a/src/content/articles/2018-11-14-breaking-down-problems-its-hard-when-you-re-learning-to-code.md
+++ b/src/content/articles/2018-11-14-breaking-down-problems-its-hard-when-you-re-learning-to-code.md
@@ -1,6 +1,6 @@
 ---
 title: 'Breaking Down Problems: It’s hard when you’re learning to code'
-redirectURL: 'https://medium.com/@dannysmith/breaking-down-problems-its-hard-when-you-re-learning-to-code-f10269f4ccd5'
-platform: medium
 pubDate: 2018-11-14
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/breaking-down-problems-its-hard-when-you-re-learning-to-code-f10269f4ccd5'
 ---

--- a/src/content/articles/2020-03-04-little-thing-mocking-external-services-on-ruby.md
+++ b/src/content/articles/2020-03-04-little-thing-mocking-external-services-on-ruby.md
@@ -1,6 +1,6 @@
 ---
 title: 'Little Thing — Mocking External Services on Ruby'
-redirectURL: 'https://medium.com/@dannysmith/little-thing-mocking-external-services-on-ruby-aeed75df11b0'
-platform: medium
 pubDate: 2020-03-04
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/little-thing-mocking-external-services-on-ruby-aeed75df11b0'
 ---

--- a/src/content/articles/2020-03-05-business-process-tooling.md
+++ b/src/content/articles/2020-03-05-business-process-tooling.md
@@ -1,6 +1,6 @@
 ---
 title: 'Business Process & Tooling'
-redirectURL: 'https://medium.com/@dannysmith/business-process-tooling-56f1e3341d21'
-platform: medium
 pubDate: 2020-03-05
+platform: medium
+redirectURL: 'https://medium.com/@dannysmith/business-process-tooling-56f1e3341d21'
 ---

--- a/src/content/articles/2020-03-14-website-redesign-i.md
+++ b/src/content/articles/2020-03-14-website-redesign-i.md
@@ -1,8 +1,8 @@
 ---
 title: Website Redesign Part I - The Tech
 slug: website-redesign-i
-pubDate: 2020-03-14
 description: Technical decisions and architecture choices for rebuilding danny.is. Learn about static site generators, JAMstack, and modern web development approaches.
+pubDate: 2020-03-14
 ---
 
 Over the years, this website has taken many forms. Initially, it was a Wordpress blog. Then is was a hand-rolled Sinatra app that rendered markdown pages. More recently I've blogged on Medium and at the time of writing, my website is a much simpler Sinatra app.

--- a/src/content/articles/2020-03-17-website-redesign-ii.mdx
+++ b/src/content/articles/2020-03-17-website-redesign-ii.mdx
@@ -1,8 +1,8 @@
 ---
 title: Website Redesign Part II - Principles, Goals and Stuff to Keep
 slug: website-redesign-ii
-pubDate: 2020-03-17
 description: Design principles and goals for a modern personal website. Balancing simplicity, performance, and content-first architecture in web design.
+pubDate: 2020-03-17
 ---
 
 import { Callout } from '@components/mdx';

--- a/src/content/articles/2020-04-07-website-redesign-iii.md
+++ b/src/content/articles/2020-04-07-website-redesign-iii.md
@@ -1,8 +1,8 @@
 ---
 title: Website Redesign Part III - A Base to Start From
 slug: website-redesign-iii
-pubDate: 2020-04-07
 description: Building a solid foundation for a personal website redesign. Technical setup, tooling choices, and development workflow for modern web projects.
+pubDate: 2020-04-07
 ---
 
 I'm trying to keep the CSS as minimal as possible here, but I do want a decent blank slate to work from. So I've normalised browser styles with [normalize.css](https://necolas.github.io/normalize.css/) and set up some of my own base styles.

--- a/src/content/articles/2022-02-10-organisational-health.mdx
+++ b/src/content/articles/2022-02-10-organisational-health.mdx
@@ -1,8 +1,8 @@
 ---
 title: Building Healthy Remote Organizations - The Silent Enabler of Success
 slug: organisational-health
-pubDate: 2022-02-10
 description: Learn how to build resilient, calm organizations that scale successfully. Proven strategies from remote work consultant Danny Smith for organizational health and team effectiveness.
+pubDate: 2022-02-10
 ---
 
 import { Callout } from '@components/mdx';

--- a/src/content/articles/2025-07-10-ai-and-adhd.mdx
+++ b/src/content/articles/2025-07-10-ai-and-adhd.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'AI and ADHD'
-pubDate: 2025-07-10T15:59:03.142Z
 slug: 'ai-and-adhd'
-description: ''
 draft: true
+description: ''
+pubDate: 2025-07-10T15:59:03.142Z
 ---
 
 import { BookmarkCard, Callout } from '@components/mdx';

--- a/src/content/notes/1700733150901-apples-thunderbolt-3-cables.md
+++ b/src/content/notes/1700733150901-apples-thunderbolt-3-cables.md
@@ -1,9 +1,9 @@
 ---
-slug: apples-thunderbolt-3-cables
 title: Apple's Thunderbolt 3 Cables
-pubDate: 2023-11-23
 sourceURL: https://youtu.be/AD5aAd8Oy84?si=SpWmlnsexh0XS4eh
+slug: apples-thunderbolt-3-cables
 description: Technical insights on Apple's Thunderbolt 3 cable design and specifications. Understanding the engineering behind premium computer accessories.
+pubDate: 2023-11-23
 ---
 
 A little while ago I bought a [Caldigit Thunderbolt 4 Dock](https://www.caldigit.com/thunderbolt-station-4/) to connect my M2 Macbook Pro to my monitors and peripherals. After struggling to get a decent signal to my monitor I eventually shelled out £130 on [this cable](https://www.apple.com/uk/shop/product/MN713ZM/A/thunderbolt-4-usb%E2%80%91c-pro-cable-18m) from Apple, which fixed things but seemd **crazy expensive for a 2m cable**.

--- a/src/content/notes/1700843296814-on-minimalist-packing.md
+++ b/src/content/notes/1700843296814-on-minimalist-packing.md
@@ -1,8 +1,8 @@
 ---
 title: On Minimalist Packing
 slug: on-minimalist-packing
-pubDate: 2023-11-24
 description: Systems thinking applied to travel. A consultant's approach to minimalist packing for remote work and efficient travel.
+pubDate: 2023-11-24
 ---
 
 Tim Feriss' [5 Bullet Friday](https://go.tim.blog/5-bullet-friday-1/) today included this quote...

--- a/src/content/notes/1712595052187-we-need-more-calm-companies.md
+++ b/src/content/notes/1712595052187-we-need-more-calm-companies.md
@@ -1,10 +1,10 @@
 ---
+title: Why Remote Companies Must Be Calm Companies
+sourceURL: https://justinjackson.ca/calm-company
 slug: we-need-more-calm-companies
 draft: true
-title: Why Remote Companies Must Be Calm Companies
-pubDate: 2024-04-08
-sourceURL: https://justinjackson.ca/calm-company
 description: Discover why calm companies outperform frenzied ones in remote work. Essential insights on sustainable growth and team well-being from organizational health expert Danny Smith.
+pubDate: 2024-04-08
 ---
 
 ## Calm Companies

--- a/src/content/notes/1752690735698-a-system-to-organise-your-life-johnnydecimal.md
+++ b/src/content/notes/1752690735698-a-system-to-organise-your-life-johnnydecimal.md
@@ -1,7 +1,7 @@
 ---
 title: 'Johnny.Decimal'
-sourceUrl: 'https://johnnydecimal.com/'
 pubDate: 2025-07-16
+sourceUrl: 'https://johnnydecimal.com/'
 ---
 
 This reminds me so much of the old UK MoD File Reference system (some of which is still in [JSP 441](https://assets.publishing.service.gov.uk/media/5a82b0d240f0b62305b93d65/2017-02121.pdf)!)

--- a/src/content/notes/2025-07-02-charles-babbage.md
+++ b/src/content/notes/2025-07-02-charles-babbage.md
@@ -1,7 +1,7 @@
 ---
 title: Charles Babbage on AI
-pubDate: 2025-07-02
 slug: charles-babbage-on-ai
+pubDate: 2025-07-02
 ---
 
 > On two occasions I have been asked, — "Pray, Mr. Babbage, if you put into the machine wrong figures, will the right answers come out ?" In one case a member of the Upper, and in the other a member of the Lower, House put this question. I am not able rightly to apprehend the kind of confusion of ideas that could provoke such a question.– _[Charles Babbage](https://archive.org/details/passagesfromlife03char/page/67/mode/1up), Passages from the Life of a Philosopher, 1864_

--- a/src/content/notes/2025-07-08-the-rise-of-the-ai-native-employee.md
+++ b/src/content/notes/2025-07-08-the-rise-of-the-ai-native-employee.md
@@ -1,8 +1,8 @@
 ---
 title: The Rise of the AI-Native Employee
-pubDate: 2025-07-08
-slug: the-rise-of-the-ai-native-employee
 sourceURL: https://www.elenaverna.com/p/the-rise-of-the-ai-native-employee
+slug: the-rise-of-the-ai-native-employee
+pubDate: 2025-07-08
 ---
 
 > AI transformation inside existing tech companies is going to be brutal. You can’t just spin up a centralized “AI task force” and expect the rest of the org to suddenly think and operate differently. It doesn’t work. This mindset shift isn’t something you can document or mandate - it has to be seen and experienced. I know, because I had to see it myself.

--- a/src/content/notes/2025-07-08-when-figma-starts-designing-us.md
+++ b/src/content/notes/2025-07-08-when-figma-starts-designing-us.md
@@ -1,8 +1,8 @@
 ---
 title: When Figma Starts Designing Us
-pubDate: 2025-07-08
-slug: when-figma-starts-designing-us
 sourceURL: https://designsystems.international/ideas/when-figma-starts-designing-us/
+slug: when-figma-starts-designing-us
+pubDate: 2025-07-08
 ---
 
 > However, over the course of the last five years, I’ve grown increasingly worried about what Figma is doing to the field of design by pushing designers toward an engineering-centric way of working. This can be seen in their feature releases: Smart Components, Variables, Auto Layout, and Interactive Prototypes. These features are often celebrated as steps toward parity with engineering, but in practice, they encourage a mode of working that narrows the field of possibility at precisely the moment when it should be expanding.


### PR DESCRIPTION
## Summary
- reorder frontmatter fields in articles and notes to match the schema order

## Testing
- `npm run lint`
- `npx prettier -c $(git ls-files)` (via format:check)


------
https://chatgpt.com/codex/tasks/task_e_687a2a7d4004832ca1e663e666d95839