### PR TITLE
Add draft notes for recent reading links

### DIFF
--- a/src/content/notes/2025-10-30-code-like-a-surgeon.md
+++ b/src/content/notes/2025-10-30-code-like-a-surgeon.md
@@ -1,0 +1,11 @@
+---
+title: 'Code Like a Surgeon'
+sourceURL: 'https://www.geoffreylitt.com/2025/10/24/code-like-a-surgeon'
+slug: code-like-a-surgeon
+draft: true
+pubDate: 2025-10-30
+---
+
+- Surgical metaphor for programming: slow setup, deliberate incisions, clean sutures, zero surprises in recovery.
+- Highlights tooling rituals (checklists, monitors, pair support) that keep changes controlled rather than chaotic heroics.
+- Inspires me to document pre-flight checklists for risky refactors so I stop improvising under pressure.

--- a/src/content/notes/2025-10-30-cursor-2-0.md
+++ b/src/content/notes/2025-10-30-cursor-2-0.md
@@ -1,0 +1,11 @@
+---
+title: 'Cursor 2.0'
+sourceURL: 'https://cursor.com/blog/2-0'
+slug: cursor-2-0
+draft: true
+pubDate: 2025-10-30
+---
+
+- Cursor relaunch leans into full-stack agent workflows: local-first editing, auto context sync, and Copilot-style plans.
+- Interesting positioning as "AI pair" that toggles between chat, edits, and diff previews rather than a monolithic chat box.
+- Worth benchmarking against my current VS Code + Claude setup to see if the new review loops shrink iteration time.

--- a/src/content/notes/2025-10-30-learn-to-read-korean-in-15-minutes.md
+++ b/src/content/notes/2025-10-30-learn-to-read-korean-in-15-minutes.md
@@ -1,0 +1,11 @@
+---
+title: 'Learn to Read Korean in 15 Minutes'
+sourceURL: 'https://www.ryanestrada.com/learntoreadkoreanin15minutes/'
+slug: learn-to-read-korean-in-15-minutes
+draft: true
+pubDate: 2025-10-30
+---
+
+- Crash course for decoding Hangul by breaking consonants and vowels into simple mouth shapes and sounds.
+- Focuses on patterns over memorisation, giving mnemonics for common syllable blocks and pronunciation shifts.
+- Handy primer to revisit before the next Korea trip or any Hangul-heavy research sprint.


### PR DESCRIPTION
## Summary
- add a draft note linking to Ryan Estrada's Hangul primer
- add a draft note for Geoffrey Litt's "Code Like a Surgeon"
- add a draft note capturing takeaways from Cursor's 2.0 announcement

## Testing
- pnpm run check *(fails: existing implicit any TypeScript errors in notes/writing route generators)*

------
https://chatgpt.com/codex/tasks/task_e_6903c62b02d0832c8a223e4401ad7186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new notes: "Code Like a Surgeon," "Cursor 2.0," and "Learn to Read Korean in 15 Minutes" to the content collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->