### PR TITLE
Add Animated TOC

### DIFF
--- a/docs/tasks-todo/task-1-toc.md
+++ b/docs/tasks-todo/task-1-toc.md
@@ -1,0 +1,436 @@
+# Task: Desktop Table of Contents with SVG Scroll Indicator
+
+## Overview
+
+Add a fixed TOC to articles on wide viewports (≥1100px) that appears to the right of the content column. An SVG path traces alongside the TOC links and animates to highlight currently visible sections as the user scrolls. Hidden completely on narrow viewports.
+
+## Technical Context
+
+**Current article grid** (in `Article.astro`):
+```css
+grid-template-columns:
+  minmax(var(--gutter), 1fr)           /* Left gutter - expands */
+  min(60ch, calc(100% - gutter * 2))   /* Content - max 60ch */
+  minmax(var(--gutter), 1fr);          /* Right gutter - expands */
+```
+
+At wide viewports, the right gutter becomes large enough to hold the TOC. Content maxes at 60ch (~600px), so on a 1400px viewport there's ~400px in each gutter.
+
+**Positioning approach**: Use `position: fixed` with `left: calc(50% + 32ch)` to place TOC just right of the centered 60ch content column.
+
+## Implementation
+
+### 1. Create `src/components/layout/TableOfContents.astro`
+
+```astro
+---
+import type { MarkdownHeading } from 'astro';
+
+export interface Props {
+  headings: MarkdownHeading[];
+}
+
+interface TocHeading extends MarkdownHeading {
+  subheadings: TocHeading[];
+}
+
+const { headings } = Astro.props;
+
+// Build nested structure from flat headings array
+function buildToc(flatHeadings: MarkdownHeading[]): TocHeading[] {
+  const toc: TocHeading[] = [];
+  const parentHeadings = new Map<number, TocHeading>();
+
+  flatHeadings
+    .filter(h => h.depth >= 2 && h.depth <= 3)
+    .forEach((h) => {
+      const heading: TocHeading = { ...h, subheadings: [] };
+      parentHeadings.set(heading.depth, heading);
+
+      if (heading.depth === 2) {
+        toc.push(heading);
+      } else {
+        // If h3 appears before any h2, treat as top-level
+        const parent = parentHeadings.get(heading.depth - 1);
+        if (parent) {
+          parent.subheadings.push(heading);
+        } else {
+          toc.push(heading);
+        }
+      }
+    });
+
+  return toc;
+}
+
+const toc = buildToc(headings);
+---
+
+{toc.length > 0 && (
+<nav class="toc ui-style" aria-label="Table of contents">
+  <ul class="toc-list">
+    {toc.map((heading) => (
+      <li>
+        <a href={`#${heading.slug}`} class="toc-link">{heading.text}</a>
+        {heading.subheadings.length > 0 && (
+          <ul class="toc-sublist">
+            {heading.subheadings.map((sub) => (
+              <li>
+                <a href={`#${sub.slug}`} class="toc-link">{sub.text}</a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </li>
+    ))}
+  </ul>
+  <!-- SVG for animated marker - positioned absolutely, path drawn by JS -->
+  <svg class="toc-marker" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-dasharray="0 0 0 1000"
+      stroke-dashoffset="1"
+    />
+  </svg>
+</nav>
+)}
+
+<style>
+  .toc {
+    /* Hidden by default */
+    display: none;
+    position: fixed;
+
+    /* Position: just right of the 60ch content column */
+    top: var(--space-xl);
+    left: calc(50% + 32ch);
+
+    /* Sizing */
+    width: 220px;
+    max-height: calc(100vh - var(--space-2xl));
+    overflow-y: auto;
+
+    /* Typography */
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+
+    /* Lower z-index than main nav */
+    z-index: 100;
+  }
+
+  @media (min-width: 1100px) {
+    .toc {
+      display: block;
+    }
+  }
+
+  .toc-list,
+  .toc-sublist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-list {
+    padding-left: var(--space-s); /* Room for SVG marker */
+  }
+
+  .toc-sublist {
+    padding-left: var(--space-m);
+  }
+
+  .toc-list li {
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-link {
+    display: block;
+    padding: var(--space-2xs) 0;
+    line-height: var(--leading-snug);
+    transition: color var(--duration-fast) var(--ease-in-out);
+  }
+
+  .toc-link:hover {
+    color: var(--color-text);
+  }
+
+  .toc-link[data-active] {
+    color: var(--color-accent);
+  }
+
+  /* SVG marker overlay */
+  .toc-marker {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    color: var(--color-accent);
+    transition: stroke-dasharray var(--duration-slow) var(--ease-in-out);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toc-marker {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  // Store cleanup function to prevent listener accumulation on ViewTransitions
+  let cleanup: (() => void) | null = null;
+
+  function initToc() {
+    // Clean up previous instance
+    cleanup?.();
+
+    const toc = document.querySelector<HTMLElement>('.toc');
+    const path = document.querySelector<SVGPathElement>('.toc-marker path');
+    const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('.toc-link'));
+
+    if (!toc || !path || links.length === 0) {
+      cleanup = null;
+      return;
+    }
+
+    // Store each link's position along the path
+    interface LinkData {
+      link: HTMLAnchorElement;
+      target: HTMLElement | null;
+      pathStart: number;
+      pathEnd: number;
+    }
+    let linkData: LinkData[] = [];
+    let pathLength = 0;
+
+    // Draw SVG path alongside links
+    function drawPath() {
+      const pathData: (string | number)[] = [];
+      let prevLeft = 0;
+
+      links.forEach((link, i) => {
+        const x = link.offsetLeft - 8; // Offset for marker line
+        const y = link.offsetTop;
+        const height = link.offsetHeight;
+
+        if (i === 0) {
+          // Move to top-left of first link, draw down
+          pathData.push('M', x, y, 'L', x, y + height);
+        } else {
+          // If indentation changed, draw horizontal first
+          if (prevLeft !== x) {
+            pathData.push('L', prevLeft, y);
+          }
+          pathData.push('L', x, y, 'L', x, y + height);
+        }
+        prevLeft = x;
+      });
+
+      path.setAttribute('d', pathData.join(' '));
+      pathLength = path.getTotalLength();
+
+      // Calculate each link's segment on the path
+      let runningLength = 0;
+      linkData = links.map((link, i) => {
+        const targetId = link.getAttribute('href')?.slice(1);
+        const target = targetId ? document.getElementById(targetId) : null;
+
+        // Approximate segment length for this link
+        const segmentLength = link.offsetHeight + (i > 0 ?
+          Math.abs(link.offsetLeft - links[i-1].offsetLeft) : 0);
+
+        const data = {
+          link,
+          target,
+          pathStart: runningLength,
+          pathEnd: runningLength + link.offsetHeight,
+        };
+
+        runningLength += segmentLength;
+        return data;
+      });
+
+      // Normalize to actual path length
+      const scale = pathLength / runningLength;
+      linkData.forEach(d => {
+        d.pathStart *= scale;
+        d.pathEnd *= scale;
+      });
+    }
+
+    // Update stroke-dasharray based on visible sections
+    function updatePath() {
+      // Find the first and last active links for continuous highlight
+      let firstActive = -1;
+      let lastActive = -1;
+
+      linkData.forEach((data, i) => {
+        if (data.link.hasAttribute('data-active')) {
+          if (firstActive === -1) firstActive = i;
+          lastActive = i;
+        }
+      });
+
+      if (firstActive === -1) {
+        // Nothing active - hide the marker
+        path.style.strokeDasharray = `0 0 0 ${pathLength}`;
+      } else {
+        // Draw from start of first active to end of last active
+        const start = linkData[firstActive].pathStart;
+        const end = linkData[lastActive].pathEnd;
+        path.style.strokeDasharray = `0 ${start} ${end - start} ${pathLength}`;
+      }
+    }
+
+    // Track visible headings with IntersectionObserver
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const id = entry.target.getAttribute('id');
+          const link = document.querySelector<HTMLAnchorElement>(`.toc-link[href="#${id}"]`);
+
+          if (entry.isIntersecting) {
+            link?.setAttribute('data-active', '');
+          } else {
+            link?.removeAttribute('data-active');
+          }
+        });
+        updatePath();
+      },
+      {
+        // Active zone: top 20% to bottom 40% of viewport
+        rootMargin: '-20% 0% -40% 0%',
+      }
+    );
+
+    // Observe all headings that have TOC links
+    linkData.forEach(({ target }) => {
+      if (target) observer.observe(target);
+    });
+
+    // Redraw on resize (debounced)
+    let resizeTimeout: ReturnType<typeof setTimeout>;
+    function handleResize() {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(drawPath, 100);
+    }
+    window.addEventListener('resize', handleResize);
+
+    // Initial setup
+    drawPath();
+    updatePath();
+
+    // Store cleanup for ViewTransitions
+    cleanup = () => {
+      observer.disconnect();
+      window.removeEventListener('resize', handleResize);
+    };
+  }
+
+  // Initialize on load and after ViewTransitions
+  initToc();
+  document.addEventListener('astro:after-swap', initToc);
+</script>
+```
+
+### 2. Modify `src/layouts/Article.astro`
+
+Add `headings` prop and render TOC:
+
+```diff
+---
+import type { CollectionEntry } from 'astro:content';
++import type { MarkdownHeading } from 'astro';
+// ... other imports
++import TableOfContents from '@components/layout/TableOfContents.astro';
+
+-type Props = CollectionEntry<'articles'>['data'] & { readingTime: string };
++type Props = CollectionEntry<'articles'>['data'] & {
++  readingTime: string;
++  headings: MarkdownHeading[];
++};
+const {
+  // ... existing props
++  headings,
+} = Astro.props;
+---
+
+<body>
+  <MainNavigation />
++ <TableOfContents headings={headings} />
+  <main>
+    <!-- existing article content -->
+  </main>
+  <Footer />
+</body>
+```
+
+### 3. Modify `src/pages/writing/[...slug]/index.astro`
+
+Pass headings through to layout:
+
+```diff
+---
+const post = Astro.props;
+-const { Content, remarkPluginFrontmatter } = await render(post);
++const { Content, headings, remarkPluginFrontmatter } = await render(post);
+const readingTime = remarkPluginFrontmatter.minutesRead;
+-const postData = { ...post.data, readingTime };
++const postData = { ...post.data, readingTime, headings };
+---
+```
+
+### 4. Export from barrel
+
+Add to `src/components/layout/index.ts`:
+
+```typescript
+export { default as TableOfContents } from './TableOfContents.astro';
+```
+
+## Key Design Decisions
+
+1. **Breakpoint: 1100px** - 60ch content (~600px) + 220px TOC + gaps needs ~1000px minimum. 1100px provides comfortable margins.
+
+2. **Position via `left: calc(50% + 32ch)`** - Centers relative to the 60ch content column. Works regardless of viewport width once past breakpoint.
+
+3. **SVG stroke-dasharray animation** - The path traces down the left edge of TOC links. `stroke-dasharray: "0 START LENGTH REST"` draws only the active segment. CSS transition animates smoothly between states.
+
+4. **Multiple active sections** - Unlike highlighting just one item, the SVG approach naturally shows a continuous line through all visible sections.
+
+5. **No JS fallback** - TOC links work without JS. Only the animated marker requires JS.
+
+## Testing Checklist
+
+- [ ] TOC visible at ≥1100px viewport
+- [ ] TOC hidden at <1100px viewport
+- [ ] SVG marker highlights current section while scrolling
+- [ ] Multiple sections highlighted when multiple headings visible
+- [ ] Marker animates smoothly between sections
+- [ ] Marker respects `prefers-reduced-motion`
+- [ ] TOC links scroll to correct sections
+- [ ] Works in light mode
+- [ ] Works in dark mode
+- [ ] ViewTransitions: TOC re-initializes after navigation
+- [ ] Empty headings array: no TOC rendered
+- [ ] Long TOC scrolls independently
+
+## Files
+
+| File | Action |
+|------|--------|
+| `src/components/layout/TableOfContents.astro` | Create |
+| `src/components/layout/index.ts` | Add export |
+| `src/layouts/Article.astro` | Add headings prop, render TOC |
+| `src/pages/writing/[...slug]/index.astro` | Pass headings to layout |
+
+## References
+
+- [kld.dev - Building a Table of Contents](https://kld.dev/building-table-of-contents/)
+- [kld.dev - TOC Progress Animation](https://kld.dev/toc-animation/)
+- [Hakim El Hattab's Progress Nav](https://lab.hakim.se/progress-nav/)

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -21,19 +21,23 @@ const today = new Date();
     </ul>
   </section>
   <section class="footer-rss all-caps">
-    <a href="/rss.xml">All</a>
+    <a href="/rss.xml" target="_blank">All</a>
     <span class="footer-rss-separator">|</span>
-    <a href="/rss/articles.xml">Articles</a>
+    <a href="/rss/articles.xml" target="_blank">Articles</a>
     <span class="footer-rss-separator">|</span>
-    <a href="/rss/notes.xml">Notes</a>
+    <a href="/rss/notes.xml" target="_blank">Notes</a>
     <span class="footer-rss-icon-wrapper">
       <Icon name="social/rss" class="footer-rss-icon" />
     </span>
   </section>
   <section class="footer-meta">
-    <a href="https://danny.is/key.txt">pgp key</a>
+    <a href="https://danny.is/key.txt" target="_blank">pgp key</a>
     <span class="footer-meta-separator">·</span>
-    <a href="https://atproto-browser.vercel.app/at/danny.is">atproto at://danny.is</a>
+    <a
+      href="https://atproto-browser.vercel.app/at/danny.is"
+      rel="me noopener noreferrer"
+      target="_blank">atproto at://danny.is</a
+    >
   </section>
   <div class="copyright all-caps">
     &copy; {today.getFullYear()} Danny Smith
@@ -107,5 +111,4 @@ const today = new Date();
   .footer-meta-separator {
     color: color-mix(in oklch, currentColor 60%, transparent);
   }
-
 </style>

--- a/src/components/layout/TableOfContents.astro
+++ b/src/components/layout/TableOfContents.astro
@@ -16,6 +16,7 @@ function buildToc(flatHeadings: MarkdownHeading[]): TocHeading[] {
   const toc: TocHeading[] = [];
   const parentHeadings = new Map<number, TocHeading>();
 
+  // Include H2 and H3 only (ignore H4+)
   flatHeadings
     .filter(h => h.depth >= 2 && h.depth <= 3)
     .forEach(h => {
@@ -179,146 +180,140 @@ const toc = buildToc(headings);
 </style>
 
 <script>
-  // Hakim El Hattab's Progress Nav approach - simple and proven
-  // https://lab.hakim.se/progress-nav/
+  // Scroll-based TOC tracking
+  // Key insight: highlight the LAST heading that has scrolled past the reading threshold
+  // This correctly handles "reading a long section where the heading has scrolled away"
+
+  const linkStarts = new WeakMap<HTMLAnchorElement, number>();
+  const linkEnds = new WeakMap<HTMLAnchorElement, number>();
 
   let defined = false;
+  let resizeObserver: ResizeObserver | null = null;
+
+  interface TocItem {
+    link: HTMLAnchorElement;
+    target: HTMLElement;
+    li: HTMLLIElement;
+  }
 
   function initToc() {
+    resizeObserver?.disconnect();
+
     const toc = document.querySelector<HTMLElement>('.toc');
     const tocPath = document.querySelector<SVGPathElement>('.toc-marker path');
 
     if (!toc || !tocPath) return;
 
-    // Prevent duplicate initialization
     if (defined) return;
     defined = true;
 
-    interface TocItem {
-      listItem: HTMLLIElement;
-      anchor: HTMLAnchorElement;
-      target: HTMLElement | null;
-      pathStart: number;
-      pathEnd: number;
-    }
+    const links = Array.from(toc.querySelectorAll<HTMLAnchorElement>('a.toc-link'));
+    if (links.length === 0) return;
 
-    let tocItems: TocItem[] = [];
-    let pathLength = 0;
-
-    // Factor of screen size that the element must cross before it's considered visible
-    const TOP_MARGIN = 0.1;
-    const BOTTOM_MARGIN = 0.2;
+    // Build list of TOC items with their target headings
+    const tocItems: TocItem[] = [];
+    links.forEach(link => {
+      const targetId = link.getAttribute('href')?.slice(1);
+      const target = targetId ? document.getElementById(targetId) : null;
+      const li = link.closest('li');
+      if (target && li) {
+        tocItems.push({ link, target, li: li as HTMLLIElement });
+      }
+    });
 
     function drawPath() {
-      if (!toc || !tocPath) return;
-      // Get all list items in the TOC
-      const listItems = Array.from(toc.querySelectorAll('li'));
-
-      // Cache element references and measurements
-      tocItems = listItems.map(item => {
-        const anchor = item.querySelector('a') as HTMLAnchorElement;
-        const targetId = anchor.getAttribute('href')?.slice(1);
-        const target = targetId ? document.getElementById(targetId) : null;
-
-        return {
-          listItem: item as HTMLLIElement,
-          anchor,
-          target,
-          pathStart: 0,
-          pathEnd: 0,
-        };
-      });
-
-      // Remove missing targets
-      tocItems = tocItems.filter(item => !!item.target);
-
-      if (tocItems.length === 0) return;
+      if (!tocPath) return;
 
       const pathData: (string | number)[] = [];
-      let pathIndent = 0;
+      let left = 0;
 
-      tocItems.forEach((item, i) => {
-        const x = item.anchor.offsetLeft - 5;
-        const y = item.anchor.offsetTop;
-        const height = item.anchor.offsetHeight;
+      links.forEach((link, i) => {
+        const x = link.offsetLeft;
+        const y = link.offsetTop;
+        const height = link.offsetHeight;
 
         if (i === 0) {
+          linkStarts.set(link, 0);
           pathData.push('M', x, y, 'L', x, y + height);
-          item.pathStart = 0;
         } else {
-          // Draw an additional line when there's a change in indent levels
-          if (pathIndent !== x) {
-            pathData.push('L', pathIndent, y);
-          }
-
+          if (left !== x) pathData.push('L', left, y);
           pathData.push('L', x, y);
-
-          // Set the current path so we can measure it
           tocPath.setAttribute('d', pathData.join(' '));
-          item.pathStart = tocPath.getTotalLength() || 0;
-
+          linkStarts.set(link, tocPath.getTotalLength());
           pathData.push('L', x, y + height);
         }
 
-        pathIndent = x;
-
+        left = x;
         tocPath.setAttribute('d', pathData.join(' '));
-        item.pathEnd = tocPath.getTotalLength();
+        linkEnds.set(link, tocPath.getTotalLength());
       });
-
-      pathLength = tocPath.getTotalLength();
-      sync();
     }
 
-    function sync() {
+    function updatePath() {
       if (!tocPath) return;
-      const windowHeight = window.innerHeight;
 
-      let pathStart = pathLength;
-      let pathEnd = 0;
-      let visibleCount = 0;
+      const pathLength = tocPath.getTotalLength();
+      const activeLink = toc!.querySelector<HTMLAnchorElement>('a.toc-link.active');
 
-      tocItems.forEach(item => {
-        if (!item.target) return;
-
-        const targetBounds = item.target.getBoundingClientRect();
-
-        // Check if the target is visible in the viewport
-        if (
-          targetBounds.bottom > windowHeight * TOP_MARGIN &&
-          targetBounds.top < windowHeight * (1 - BOTTOM_MARGIN)
-        ) {
-          pathStart = Math.min(item.pathStart, pathStart);
-          pathEnd = Math.max(item.pathEnd, pathEnd);
-          visibleCount++;
-          item.listItem.classList.add('visible');
-        } else {
-          item.listItem.classList.remove('visible');
-        }
-      });
-
-      // Update the path to show the visible range
-      if (visibleCount > 0 && pathStart < pathEnd) {
-        tocPath.setAttribute('stroke-dashoffset', '1');
-        tocPath.setAttribute(
-          'stroke-dasharray',
-          `1, ${pathStart}, ${pathEnd - pathStart}, ${pathLength}`
-        );
-        tocPath.style.opacity = '1';
+      if (activeLink) {
+        const start = linkStarts.get(activeLink) ?? 0;
+        const end = linkEnds.get(activeLink) ?? 0;
+        tocPath.style.display = 'inline';
+        tocPath.setAttribute('stroke-dasharray', `1 ${start} ${end - start} ${pathLength}`);
       } else {
-        tocPath.style.opacity = '0';
+        tocPath.style.display = 'none';
       }
     }
 
-    // Set up event listeners
-    window.addEventListener('resize', drawPath);
+    function sync() {
+      // Reading threshold: ~33% from top of viewport
+      // Headings become active when they enter upper third (where eyes typically read)
+      const threshold = window.innerHeight * 0.33;
+
+      // Find the last heading that has scrolled past the threshold
+      // This is the section we're currently "in"
+      let activeItem: TocItem | null = null;
+
+      for (const item of tocItems) {
+        const rect = item.target.getBoundingClientRect();
+        if (rect.top <= threshold) {
+          activeItem = item;
+        } else {
+          // Headings are in document order, so once we find one below threshold, stop
+          break;
+        }
+      }
+
+      // Clear all active states
+      tocItems.forEach(item => {
+        item.link.classList.remove('active');
+        item.li.classList.remove('visible');
+      });
+
+      // Set the active one
+      if (activeItem) {
+        activeItem.link.classList.add('active');
+        activeItem.li.classList.add('visible');
+      }
+
+      updatePath();
+    }
+
+    // Handle layout changes
+    resizeObserver = new ResizeObserver(() => {
+      drawPath();
+      updatePath();
+    });
+    resizeObserver.observe(toc);
+
+    // Scroll listener
     window.addEventListener('scroll', sync, { passive: true });
 
     // Initial setup
     drawPath();
+    sync();
   }
 
-  // Initialize
   initToc();
   document.addEventListener('astro:after-swap', () => {
     defined = false;

--- a/src/components/layout/TableOfContents.astro
+++ b/src/components/layout/TableOfContents.astro
@@ -1,0 +1,321 @@
+---
+import type { MarkdownHeading } from 'astro';
+
+export interface Props {
+  headings: MarkdownHeading[];
+}
+
+interface TocHeading extends MarkdownHeading {
+  subheadings: TocHeading[];
+}
+
+const { headings } = Astro.props;
+
+// Build nested structure from flat headings array
+function buildToc(flatHeadings: MarkdownHeading[]): TocHeading[] {
+  const toc: TocHeading[] = [];
+  const parentHeadings = new Map<number, TocHeading>();
+
+  flatHeadings
+    .filter(h => h.depth >= 2 && h.depth <= 3)
+    .forEach(h => {
+      const heading: TocHeading = { ...h, subheadings: [] };
+      parentHeadings.set(heading.depth, heading);
+
+      if (heading.depth === 2) {
+        toc.push(heading);
+      } else {
+        const parent = parentHeadings.get(heading.depth - 1);
+        if (parent) {
+          parent.subheadings.push(heading);
+        } else {
+          toc.push(heading);
+        }
+      }
+    });
+
+  return toc;
+}
+
+const toc = buildToc(headings);
+---
+
+{
+  toc.length > 0 && (
+    <aside class="toc-wrapper">
+      <nav class="toc" aria-label="Table of contents">
+        <ul class="toc-list">
+          {toc.map(heading => (
+            <li>
+              <a href={`#${heading.slug}`} class="toc-link">
+                {heading.text}
+              </a>
+              {heading.subheadings.length > 0 && (
+                <ul class="toc-sublist">
+                  {heading.subheadings.map(sub => (
+                    <li>
+                      <a href={`#${sub.slug}`} class="toc-link">
+                        {sub.text}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
+        <svg class="toc-marker" xmlns="http://www.w3.org/2000/svg">
+          <path
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-dasharray="1 0 0 1000"
+            stroke-dashoffset="1"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </nav>
+    </aside>
+  )
+}
+
+<style>
+  .toc-wrapper {
+    display: none;
+    position: absolute;
+    top: 26rem;
+    left: var(--space-s);
+    width: calc(calc(100vw - var(--measure-standard)) / 2);
+    height: 100%;
+  }
+
+  @media (min-width: 1100px) {
+    .toc-wrapper {
+      display: block;
+    }
+  }
+
+  .toc {
+    position: sticky;
+    top: var(--space-l);
+    font-size: var(--font-size-sm);
+    z-index: 100;
+  }
+
+  .toc-list,
+  .toc-sublist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-list {
+    position: relative;
+    /* Padding creates space for the SVG marker on the left */
+    padding-left: var(--space-m);
+  }
+
+  .toc-sublist {
+    padding-left: var(--space-s);
+  }
+
+  .toc-list li {
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-link {
+    display: block;
+    padding: var(--space-2xs) 0;
+    padding-left: var(--space-xs);
+    line-height: var(--leading-snug);
+    color: color-mix(in oklch, var(--color-text) 50%, transparent);
+    text-decoration: none;
+    overflow-wrap: break-word;
+    transition: color var(--duration-fast) var(--ease-in-out);
+  }
+
+  .toc-link:hover {
+    color: var(--color-text);
+  }
+
+  li.visible > .toc-link {
+    color: var(--color-accent);
+  }
+
+  .toc-marker {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    color: color-mix(in oklch, var(--color-accent) 50%, transparent);
+    transition: color var(--duration-fast) var(--ease-in-out);
+  }
+
+  .toc:hover .toc-marker {
+    color: var(--color-accent);
+  }
+
+  .toc-marker path {
+    transition:
+      stroke-dasharray 0.3s ease,
+      opacity 0.3s ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toc-marker path {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  // Hakim El Hattab's Progress Nav approach - simple and proven
+  // https://lab.hakim.se/progress-nav/
+
+  let defined = false;
+
+  function initToc() {
+    const toc = document.querySelector<HTMLElement>('.toc');
+    const tocPath = document.querySelector<SVGPathElement>('.toc-marker path');
+
+    if (!toc || !tocPath) return;
+
+    // Prevent duplicate initialization
+    if (defined) return;
+    defined = true;
+
+    interface TocItem {
+      listItem: HTMLLIElement;
+      anchor: HTMLAnchorElement;
+      target: HTMLElement | null;
+      pathStart: number;
+      pathEnd: number;
+    }
+
+    let tocItems: TocItem[] = [];
+    let pathLength = 0;
+
+    // Factor of screen size that the element must cross before it's considered visible
+    const TOP_MARGIN = 0.1;
+    const BOTTOM_MARGIN = 0.2;
+
+    function drawPath() {
+      if (!toc || !tocPath) return;
+      // Get all list items in the TOC
+      const listItems = Array.from(toc.querySelectorAll('li'));
+
+      // Cache element references and measurements
+      tocItems = listItems.map(item => {
+        const anchor = item.querySelector('a') as HTMLAnchorElement;
+        const targetId = anchor.getAttribute('href')?.slice(1);
+        const target = targetId ? document.getElementById(targetId) : null;
+
+        return {
+          listItem: item as HTMLLIElement,
+          anchor,
+          target,
+          pathStart: 0,
+          pathEnd: 0,
+        };
+      });
+
+      // Remove missing targets
+      tocItems = tocItems.filter(item => !!item.target);
+
+      if (tocItems.length === 0) return;
+
+      const pathData: (string | number)[] = [];
+      let pathIndent = 0;
+
+      tocItems.forEach((item, i) => {
+        const x = item.anchor.offsetLeft - 5;
+        const y = item.anchor.offsetTop;
+        const height = item.anchor.offsetHeight;
+
+        if (i === 0) {
+          pathData.push('M', x, y, 'L', x, y + height);
+          item.pathStart = 0;
+        } else {
+          // Draw an additional line when there's a change in indent levels
+          if (pathIndent !== x) {
+            pathData.push('L', pathIndent, y);
+          }
+
+          pathData.push('L', x, y);
+
+          // Set the current path so we can measure it
+          tocPath.setAttribute('d', pathData.join(' '));
+          item.pathStart = tocPath.getTotalLength() || 0;
+
+          pathData.push('L', x, y + height);
+        }
+
+        pathIndent = x;
+
+        tocPath.setAttribute('d', pathData.join(' '));
+        item.pathEnd = tocPath.getTotalLength();
+      });
+
+      pathLength = tocPath.getTotalLength();
+      sync();
+    }
+
+    function sync() {
+      if (!tocPath) return;
+      const windowHeight = window.innerHeight;
+
+      let pathStart = pathLength;
+      let pathEnd = 0;
+      let visibleCount = 0;
+
+      tocItems.forEach(item => {
+        if (!item.target) return;
+
+        const targetBounds = item.target.getBoundingClientRect();
+
+        // Check if the target is visible in the viewport
+        if (
+          targetBounds.bottom > windowHeight * TOP_MARGIN &&
+          targetBounds.top < windowHeight * (1 - BOTTOM_MARGIN)
+        ) {
+          pathStart = Math.min(item.pathStart, pathStart);
+          pathEnd = Math.max(item.pathEnd, pathEnd);
+          visibleCount++;
+          item.listItem.classList.add('visible');
+        } else {
+          item.listItem.classList.remove('visible');
+        }
+      });
+
+      // Update the path to show the visible range
+      if (visibleCount > 0 && pathStart < pathEnd) {
+        tocPath.setAttribute('stroke-dashoffset', '1');
+        tocPath.setAttribute(
+          'stroke-dasharray',
+          `1, ${pathStart}, ${pathEnd - pathStart}, ${pathLength}`
+        );
+        tocPath.style.opacity = '1';
+      } else {
+        tocPath.style.opacity = '0';
+      }
+    }
+
+    // Set up event listeners
+    window.addEventListener('resize', drawPath);
+    window.addEventListener('scroll', sync, { passive: true });
+
+    // Initial setup
+    drawPath();
+  }
+
+  // Initialize
+  initToc();
+  document.addEventListener('astro:after-swap', () => {
+    defined = false;
+    initToc();
+  });
+</script>

--- a/src/components/layout/TableOfContents.astro
+++ b/src/components/layout/TableOfContents.astro
@@ -84,7 +84,7 @@ const toc = buildToc(headings);
   .toc-wrapper {
     display: none;
     position: absolute;
-    top: 26rem;
+    top: 27rem;
     left: var(--space-s);
     width: calc(calc(100vw - var(--measure-standard)) / 2);
     height: 100%;
@@ -100,7 +100,13 @@ const toc = buildToc(headings);
     position: sticky;
     top: var(--space-l);
     font-size: var(--font-size-sm);
-    z-index: 100;
+    font-weight: var(--font-weight-medium);
+    font-optical-sizing: auto;
+    font-variant-caps: all-small-caps;
+    font-variant-numeric: tabular-nums;
+    font-variant-ligatures: common-ligatures;
+
+    letter-spacing: var(--tracking-tight);
   }
 
   .toc-list,

--- a/src/components/layout/TableOfContents.astro
+++ b/src/components/layout/TableOfContents.astro
@@ -91,7 +91,7 @@ const toc = buildToc(headings);
     height: 100%;
   }
 
-  @media (min-width: 1100px) {
+  @media (min-width: 1400px) {
     .toc-wrapper {
       display: block;
     }

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -4,6 +4,7 @@ export { default as Footer } from './Footer.astro';
 export { default as MainNavigation } from './MainNavigation.astro';
 export { default as NoteCard } from './NoteCard.astro';
 export { default as Lightbox } from './Lightbox.astro';
+export { default as TableOfContents } from './TableOfContents.astro';
 
 // Typography wrapper components
 export { default as LongFormProseTypography } from './LongFormProseTypography.astro';

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -7,17 +7,25 @@ const articles = defineCollection({
   schema: ({ image }) =>
     z.object({
       title: z.string(),
-      slug: z.string().optional(), // Custom URL slug
+      slug: z.string().optional().describe('Custom URL slug (defaults to filename)'),
       draft: z.boolean().default(false),
-      description: z.string().optional(), // SEO meta description
-      pubDate: z.coerce.date(), // Publication date
-      updatedDate: z.coerce.date().optional(), // Last updated date
-      cover: image().optional(), // Header image
-      coverAlt: z.string().optional(), // Alt text for header image
+      toc: z.boolean().default(false).describe('Show table of contents sidebar on wide viewports'),
+      description: z.string().optional(),
+      pubDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      cover: image().optional(),
+      coverAlt: z.string().optional(),
       tags: z.array(z.string()).optional(),
-      platform: z.enum(['medium', 'external']).optional(), // For articles published elsewhere (Medium, etc.)
-      redirectURL: z.string().url().optional(), // For articles published elsewhere – where to redirect to
-      styleguide: z.boolean().optional(), // Flag for the article styleguide. Excludes from RSS/indexes etc in prod
+      platform: z
+        .enum(['medium', 'external'])
+        .optional()
+        .describe('For articles published elsewhere'),
+      redirectURL: z
+        .string()
+        .url()
+        .optional()
+        .describe('Redirect destination for external articles'),
+      styleguide: z.boolean().optional().describe('Styleguide page; excluded from RSS and indexes'),
     }),
 });
 
@@ -26,13 +34,13 @@ const notes = defineCollection({
   loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/notes' }),
   schema: z.object({
     title: z.string(),
-    sourceURL: z.string().url().optional(), // Original URL for link posts
-    slug: z.string().optional(), // Custom URL slug
+    sourceURL: z.string().url().optional().describe('Original URL for link posts'),
+    slug: z.string().optional().describe('Custom URL slug (defaults to filename)'),
     draft: z.boolean().default(false),
-    description: z.string().optional(), // SEO description
+    description: z.string().optional(),
     pubDate: z.coerce.date(),
     tags: z.array(z.string()).optional(),
-    styleguide: z.boolean().optional(), // Flag for the article styleguide. Excludes from RSS/indexes etc in prod
+    styleguide: z.boolean().optional().describe('Styleguide page; excluded from RSS and indexes'),
   }),
 });
 

--- a/src/content/articles/2022-02-10-organisational-health.mdx
+++ b/src/content/articles/2022-02-10-organisational-health.mdx
@@ -1,7 +1,7 @@
 ---
 title: Building Healthy Remote Organizations - The Silent Enabler of Success
 slug: organisational-health
-description: 'Learn how to build resilient, calm organizations that scale successfully. Proven strategies from remote work consultant Danny Smith for organizational health and team effectiveness.'
+description: Learn how to build resilient, calm organizations that scale successfully. Proven strategies from remote work consultant Danny Smith for organizational health and team effectiveness.
 pubDate: 2022-02-10
 ---
 

--- a/src/content/articles/2025-07-26-astro-editor.mdx
+++ b/src/content/articles/2025-07-26-astro-editor.mdx
@@ -2,6 +2,7 @@
 title: Announcing Astro Editor 1.0.0
 slug: introducing-astro-editor
 draft: true
+toc: true
 pubDate: 2025-11-26
 cover: ../../assets/articles/2025-11-26-blog-header.png
 ---

--- a/src/content/articles/2025-10-25-moving-to-astro.mdx
+++ b/src/content/articles/2025-10-25-moving-to-astro.mdx
@@ -1,7 +1,8 @@
 ---
-title: 'Moving this site to Astro'
+title: Moving this site to Astro
 slug: moving-to-astro
 draft: false
+toc: true
 pubDate: 2025-10-25
 ---
 

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -28,6 +28,7 @@ const {
   platform,
   readingTime,
   headings,
+  toc,
 } = Astro.props;
 
 // Build OG image path for this article
@@ -58,7 +59,7 @@ const ogImage = `/writing/${Astro.params.slug}/og-image.png`;
     }
     <main>
       <article class="h-entry" itemscope itemtype="https://schema.org/Article">
-        <TableOfContents headings={headings} />
+        {toc && <TableOfContents headings={headings} />}
         <LongFormProseTypography>
           {
             cover && coverAlt && (

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -1,5 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
+import type { MarkdownHeading } from 'astro';
 import { Image } from 'astro:assets';
 import Spinner from '@components/ui/Spinner.astro';
 import BaseHead from '@components/layout/BaseHead.astro';
@@ -9,8 +10,12 @@ import Lightbox from '@components/layout/Lightbox.astro';
 import MainNavigation from '@components/layout/MainNavigation.astro';
 import LongFormProseTypography from '@components/layout/LongFormProseTypography.astro';
 import MarkdownContentActions from '@components/ui/MarkdownContentActions.astro';
+import TableOfContents from '@components/layout/TableOfContents.astro';
 
-type Props = CollectionEntry<'articles'>['data'] & { readingTime: string };
+type Props = CollectionEntry<'articles'>['data'] & {
+  readingTime: string;
+  headings: MarkdownHeading[];
+};
 const {
   title,
   description,
@@ -22,6 +27,7 @@ const {
   redirectURL,
   platform,
   readingTime,
+  headings,
 } = Astro.props;
 
 // Build OG image path for this article
@@ -52,6 +58,7 @@ const ogImage = `/writing/${Astro.params.slug}/og-image.png`;
     }
     <main>
       <article class="h-entry" itemscope itemtype="https://schema.org/Article">
+        <TableOfContents headings={headings} />
         <LongFormProseTypography>
           {
             cover && coverAlt && (
@@ -93,6 +100,11 @@ const ogImage = `/writing/${Astro.params.slug}/og-image.png`;
     <Footer />
     <Lightbox />
     <style>
+      /* Article needs position context for TOC */
+      article {
+        position: relative;
+      }
+
       /* Article grid layout - 3 columns for full-bleed support */
       :global(.longform-prose) {
         --gutter: var(--space-m);
@@ -196,7 +208,9 @@ const ogImage = `/writing/${Astro.params.slug}/og-image.png`;
         const footnoteElement = document.getElementById(footnoteId);
 
         // Find the closest block-level parent (p, div, li, etc.)
-        const closestBlock = elm.closest('p, .intro-paragraph, li, blockquote, div.longform-prose > *');
+        const closestBlock = elm.closest(
+          'p, .intro-paragraph, li, blockquote, div.longform-prose > *'
+        );
         if (!closestBlock || !footnoteElement?.firstElementChild) return;
 
         const inlineFootNoteContainer = document.createElement('div');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,12 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '@config/seo';
   </head>
   <body itemtype="https://schema.org/ProfilePage" itemscope>
     <MainNavigation />
-    <main class="vcard h-card ui-style" itemtype="http://schema.org/Person" itemprop="mainEntity" itemscope>
+    <main
+      class="vcard h-card ui-style"
+      itemtype="http://schema.org/Person"
+      itemprop="mainEntity"
+      itemscope
+    >
       <a rel="me" href={Astro.site?.href} class="u-url u-uid hidden-microformat">Danny Smith</a>
       <h1 class="fn p-name" itemprop="name">
         <span itemprop="givenName">Danny</span>
@@ -26,16 +31,22 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '@config/seo';
           <a href="/notes"><strong>notes</strong></a>
         </li>
         <li>
-          <a href="/toolbox"><strong>remote working</strong> <span>toolbox</span></a>
+          <a href="/now"><strong>now</strong></a>
         </li>
         <li>
-          <a href="/youtube"><strong>youtube</strong></a>
+          <a href="https://betterat.work"><strong>work</strong></a>
+        </li>
+        <li>
+          <a href="/toolbox"><strong>toolbox</strong></a>
         </li>
         <li>
           <a href="/using">stuff I'm <strong>using</strong></a>
         </li>
         <li>
-          <a href="/music">my <b>music</b></a>
+          <a href="/youtube"><strong>youtube</strong></a>
+        </li>
+        <li>
+          <a href="/music"><strong>music</strong></a>
         </li>
         <li>
           <a href="https://www.linkedin.com/in/dannyasmith" rel="me" target="_blank"
@@ -49,13 +60,8 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '@config/seo';
         </li>
         <li>
           <a href="https://indieweb.social/@dannysmith" rel="me" target="_blank">
-            <strong>Mastodon</strong><span>@dannyasmith@indieweb.social</span>
+            <strong>Mastodon</strong>
           </a>
-        </li>
-        <li>
-          <a href="https://medium.com/@dannysmith" rel="me" target="_blank"
-            ><strong>medium</strong><span>/dannysmith</span></a
-          >
         </li>
         <li>
           <a href="https://github.com/dannysmith" rel="me" target="_blank"
@@ -77,11 +83,6 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '@config/seo';
             ><strong>email</strong></a
           >
         </li>
-        <li>
-          <a href="https://atproto-browser.vercel.app/at/danny.is" rel="me" target="_blank"
-            >at://danny.is</a
-          >
-        </li>
       </ul>
       <Image
         src="/icon.jpg"
@@ -95,7 +96,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '@config/seo';
         itemprop="image"
       />
 
-<style>
+      <style>
         main {
           display: grid;
           grid-template-columns: 1rem auto 1fr;
@@ -144,7 +145,6 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '@config/seo';
 
           .link-list {
             grid-column: 1;
-
 
             & a {
               display: flex;

--- a/src/pages/writing/[...slug]/index.astro
+++ b/src/pages/writing/[...slug]/index.astro
@@ -14,9 +14,9 @@ export async function getStaticPaths() {
 type Props = CollectionEntry<'articles'>;
 
 const post = Astro.props;
-const { Content, remarkPluginFrontmatter } = await render(post);
+const { Content, headings, remarkPluginFrontmatter } = await render(post);
 const readingTime = remarkPluginFrontmatter.minutesRead;
-const postData = { ...post.data, readingTime };
+const postData = { ...post.data, readingTime, headings };
 ---
 
 <Article {...postData}>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add an animated, scroll-synced Table of Contents for articles and wire headings through layout with per-article `toc` opt-in.
> 
> - **UI/Article Layout**:
>   - Add `src/components/layout/TableOfContents.astro` with SVG path indicator; highlights active H2/H3 while scrolling.
>   - Render TOC in `src/layouts/Article.astro` when `toc` is true; article positioned for TOC overlay; sticky/absolute TOC styling.
>   - Pass `headings` from page to layout (`src/pages/writing/[...slug]/index.astro`); export via `src/components/layout/index.ts`.
> - **Content Schema & Posts**:
>   - Extend `src/content.config.ts` with `toc: boolean` (default false) and clearer field descriptions.
>   - Enable TOC in select articles (`2025-10-25-moving-to-astro.mdx`, `2025-07-26-astro-editor.mdx`); minor frontmatter text tweaks.
> - **Site Chrome**:
>   - Footer: open RSS and external links in new tabs; add `rel` attributes.
>   - Home page links reorganized and updated.
> - **Docs**:
>   - Add implementation plan and checklist in `docs/tasks-todo/task-1-toc.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 571f70a536036a44372a8d84e49420315e52c933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added optional Table of Contents sidebar for articles on wide viewports, featuring scroll-based section highlighting and navigation.

* **Improvements**
  - Refreshed homepage navigation links and social profile presentation.
  - Enhanced footer links to open in new tabs for improved browsing experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->