### PR TITLE
Add rehype-list-density plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import rehypeMermaid from 'rehype-mermaid';
 import { mermaidConfig } from './src/config/mermaid.js';
 import { remarkReadingTime } from './src/lib/remark-reading-time.mjs';
 import { remarkFootnoteDetector } from './src/lib/remark-footnote-detector.mjs';
+import { rehypeListDensity } from './src/lib/rehype-list-density.mjs';
 import icon from 'astro-icon';
 import { redirects } from './src/config/redirects.ts';
 
@@ -69,6 +70,7 @@ export default defineConfig({
       rehypeAutolinkHeadings,
       [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
       [rehypeMermaid, { mermaidConfig }],
+      rehypeListDensity,
     ],
     remarkPlugins: [remarkReadingTime, remarkFootnoteDetector],
   },

--- a/src/lib/rehype-list-density.mjs
+++ b/src/lib/rehype-list-density.mjs
@@ -66,7 +66,9 @@ export function rehypeListDensity(options = {}) {
 
       if (avgChars > threshold) {
         node.properties = node.properties || {};
-        node.properties.className = [...(node.properties.className || []), 'long-list-items'];
+        const existing = node.properties.className;
+        const classes = Array.isArray(existing) ? existing : existing ? existing.split(/\s+/) : [];
+        node.properties.className = [...classes, 'long-list-items'];
       }
     });
   };

--- a/src/lib/rehype-list-density.mjs
+++ b/src/lib/rehype-list-density.mjs
@@ -1,0 +1,73 @@
+/**
+ * Rehype plugin to detect lists with long/paragraph-like items
+ *
+ * Adds the class `long-list-items` to top-level ul/ol elements where the
+ * average text length per list item exceeds a threshold. This allows CSS
+ * to apply more generous spacing between items in prose-heavy lists.
+ *
+ * - Only applies to top-level lists (not nested lists)
+ * - Excludes text inside nested lists when calculating item length
+ * - Threshold defaults to 120 characters average per item
+ *
+ * @example
+ * // In astro.config.mjs
+ * import { rehypeListDensity } from './src/lib/rehype-list-density.mjs';
+ *
+ * export default defineConfig({
+ *   markdown: {
+ *     rehypePlugins: [rehypeListDensity]
+ *   }
+ * });
+ *
+ * @param {Object} options
+ * @param {number} [options.threshold=120] - Average chars per item to trigger class
+ * @returns {Function} Rehype transformer function
+ */
+import { visit } from 'unist-util-visit';
+
+/**
+ * Get the text length of a node, excluding nested lists
+ */
+function getDirectTextLength(node) {
+  let length = 0;
+  for (const child of node.children || []) {
+    if (child.type === 'text') {
+      length += child.value.length;
+    } else if (child.type === 'element' && child.tagName !== 'ul' && child.tagName !== 'ol') {
+      // Recurse into inline elements (em, strong, a, code, etc.) but not lists
+      length += getDirectTextLength(child);
+    }
+  }
+  return length;
+}
+
+export function rehypeListDensity(options = {}) {
+  const threshold = options.threshold ?? 120;
+
+  return tree => {
+    visit(tree, 'element', (node, _index, parent) => {
+      // Only process ul/ol
+      if (node.tagName !== 'ul' && node.tagName !== 'ol') return;
+
+      // Skip if nested inside another list item (not a top-level list)
+      if (parent?.tagName === 'li') return;
+
+      // Get all direct li children
+      const items = node.children.filter(c => c.tagName === 'li');
+      if (items.length === 0) return;
+
+      // Calculate total text length across all items
+      let totalChars = 0;
+      for (const li of items) {
+        totalChars += getDirectTextLength(li);
+      }
+
+      const avgChars = totalChars / items.length;
+
+      if (avgChars > threshold) {
+        node.properties = node.properties || {};
+        node.properties.className = [...(node.properties.className || []), 'long-list-items'];
+      }
+    });
+  };
+}

--- a/src/pages/styleguide/_Typography.astro
+++ b/src/pages/styleguide/_Typography.astro
@@ -11,6 +11,7 @@ import {
   highlight as Highlight,
 } from '@components/mdx/index';
 import { Content as ChecklistContent } from './_snippets/checklist.mdx';
+import { Content as ListDensityContent } from './_snippets/list-density.mdx';
 ---
 
 <section id="typography" class="styleguide-section flow">
@@ -277,7 +278,20 @@ import { Content as ChecklistContent } from './_snippets/checklist.mdx';
     <ChecklistContent />
   </SGTypographySwitcher>
 
-  <!-- 8. Tables -->
+  <!-- 8. Lists: Density-Based Spacing -->
+  <h3 id="lists-density">List Density</h3>
+  <SGTypographySwitcher>
+    <h2>Automatic Spacing for Long List Items</h2>
+    <p>
+      Lists with short items use tight spacing, while lists with paragraph-like items
+      automatically receive more generous spacing. The <code>.long-list-items</code> class
+      is added by a rehype plugin when the average text length per item exceeds a threshold.
+      This is rendered from MDX to test the plugin:
+    </p>
+    <ListDensityContent />
+  </SGTypographySwitcher>
+
+  <!-- 9. Tables -->
   <h3 id="tables">Tables</h3>
   <SGTypographySwitcher>
     <h2>Tabular Data</h2>

--- a/src/pages/styleguide/_snippets/list-density.mdx
+++ b/src/pages/styleguide/_snippets/list-density.mdx
@@ -1,0 +1,20 @@
+A short-item list (should NOT get the class):
+
+- First item
+- Second item
+- Third item
+- Fourth item
+
+A long-item list where each item is essentially a paragraph (should get `.long-list-items`):
+
+- When writing documentation, it's important to consider the reader's context and provide enough background information that they can understand the topic without needing to consult external resources.
+- Code examples should be complete and runnable whenever possible, rather than showing isolated snippets that leave readers guessing about imports, configuration, or surrounding context.
+- Error messages and edge cases deserve special attention because these are often the situations where readers most need guidance, yet they're frequently overlooked in favour of happy-path documentation.
+
+A nested list where the outer items are short (nested content shouldn't affect the outer list):
+
+- Setup requirements
+  - This nested item is quite long and contains a lot of detail about the specific requirements for setting up the development environment, including all the tools and dependencies.
+  - Another detailed nested item explaining configuration options and recommended settings for optimal performance.
+- Installation steps
+- Running tests

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -702,6 +702,11 @@
     list-style-type: '•';
   }
 
+  /* Long list items */
+  .long-list-items {
+    /* TODO: Improve spacing between long list items */
+  }
+
   /* Blockquotes */
   blockquote {
     border-left: var(--border-width-thick) solid var(--color-accent);

--- a/tests/unit/rehype-list-density.test.ts
+++ b/tests/unit/rehype-list-density.test.ts
@@ -69,6 +69,31 @@ describe('rehypeListDensity', () => {
       expect(ul.properties?.className).toContain('existing-class');
       expect(ul.properties?.className).toContain('long-list-items');
     });
+
+    it('handles className as string (non-standard but possible)', () => {
+      const longText =
+        'This is a much longer list item that contains enough text to exceed the default threshold of 120 characters when averaged across all items.';
+      const tree: Root = {
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'ul',
+            properties: { className: 'existing-class another-class' as unknown as string[] },
+            children: [li(longText), li(longText)],
+          },
+        ],
+      };
+
+      transform(tree);
+
+      const ul = tree.children[0] as Element;
+      const classes = ul.properties?.className as string[];
+      expect(classes).toContain('existing-class');
+      expect(classes).toContain('another-class');
+      expect(classes).toContain('long-list-items');
+      expect(classes).toHaveLength(3);
+    });
   });
 
   describe('nested list handling', () => {

--- a/tests/unit/rehype-list-density.test.ts
+++ b/tests/unit/rehype-list-density.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { rehypeListDensity } from '../../src/lib/rehype-list-density.mjs';
+import type { Element, Root } from 'hast';
+
+/** Helper to create a text node */
+const text = (value: string) => ({ type: 'text' as const, value });
+
+/** Helper to create an element node */
+const el = (
+  tagName: string,
+  children: (Element | { type: 'text'; value: string })[] = [],
+  className?: string[]
+): Element => ({
+  type: 'element',
+  tagName,
+  properties: className ? { className } : {},
+  children,
+});
+
+/** Helper to create a list item with text */
+const li = (content: string) => el('li', [text(content)]);
+
+/** Run the plugin on a tree and return the modified tree */
+const transform = (tree: Root, options?: { threshold?: number }) => {
+  const plugin = rehypeListDensity(options);
+  plugin(tree);
+  return tree;
+};
+
+describe('rehypeListDensity', () => {
+  describe('class application', () => {
+    it('does not add class to lists with short items', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [el('ul', [li('Short item'), li('Another short'), li('Third one')])],
+      };
+
+      transform(tree);
+
+      const ul = tree.children[0] as Element;
+      expect(ul.properties?.className).toBeUndefined();
+    });
+
+    it('adds class to lists with long items', () => {
+      const longText =
+        'This is a much longer list item that contains enough text to exceed the default threshold of 120 characters when averaged across all items in the list.';
+      const tree: Root = {
+        type: 'root',
+        children: [el('ul', [li(longText), li(longText)])],
+      };
+
+      transform(tree);
+
+      const ul = tree.children[0] as Element;
+      expect(ul.properties?.className).toContain('long-list-items');
+    });
+
+    it('preserves existing classes when adding long-list-items', () => {
+      const longText =
+        'This is a much longer list item that contains enough text to exceed the default threshold of 120 characters when averaged across all items.';
+      const tree: Root = {
+        type: 'root',
+        children: [el('ul', [li(longText), li(longText)], ['existing-class'])],
+      };
+
+      transform(tree);
+
+      const ul = tree.children[0] as Element;
+      expect(ul.properties?.className).toContain('existing-class');
+      expect(ul.properties?.className).toContain('long-list-items');
+    });
+  });
+
+  describe('nested list handling', () => {
+    it('does not add class to nested lists', () => {
+      const longText =
+        'This is a very long nested list item that would normally trigger the class if it were a top-level list but should not here.';
+      const tree: Root = {
+        type: 'root',
+        children: [
+          el('ul', [el('li', [text('Parent item'), el('ul', [li(longText), li(longText)])])]),
+        ],
+      };
+
+      transform(tree);
+
+      const outerUl = tree.children[0] as Element;
+      const innerLi = outerUl.children[0] as Element;
+      const innerUl = innerLi.children[1] as Element;
+
+      expect(outerUl.properties?.className).toBeUndefined();
+      expect(innerUl.properties?.className).toBeUndefined();
+    });
+
+    it('excludes nested list text from parent item length calculation', () => {
+      const longNestedText =
+        'This nested content is very long and would push the average over the threshold if it were counted, but it should be excluded from the calculation.';
+      const tree: Root = {
+        type: 'root',
+        children: [
+          el('ul', [
+            el('li', [text('Short'), el('ul', [li(longNestedText)])]),
+            li('Also short'),
+            li('Third short'),
+          ]),
+        ],
+      };
+
+      transform(tree);
+
+      const ul = tree.children[0] as Element;
+      expect(ul.properties?.className).toBeUndefined();
+    });
+  });
+
+  describe('threshold configuration', () => {
+    it('respects custom threshold option', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [
+          el('ul', [
+            li('This is about fifty characters of text here.'),
+            li('And this one is also around fifty chars total.'),
+          ]),
+        ],
+      };
+
+      // With default threshold (120), should not get class
+      transform(tree);
+      expect((tree.children[0] as Element).properties?.className).toBeUndefined();
+
+      // With lower threshold (40), should get class
+      const tree2: Root = {
+        type: 'root',
+        children: [
+          el('ul', [
+            li('This is about fifty characters of text here.'),
+            li('And this one is also around fifty chars total.'),
+          ]),
+        ],
+      };
+      transform(tree2, { threshold: 40 });
+      expect((tree2.children[0] as Element).properties?.className).toContain('long-list-items');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty lists gracefully', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [el('ul', [])],
+      };
+
+      expect(() => transform(tree)).not.toThrow();
+      expect((tree.children[0] as Element).properties?.className).toBeUndefined();
+    });
+
+    it('counts text inside inline elements (em, strong, a, code)', () => {
+      const tree: Root = {
+        type: 'root',
+        children: [
+          el('ul', [
+            el('li', [
+              text('Start '),
+              el('strong', [text('bold text that adds to the character count')]),
+              text(' and '),
+              el('a', [text('a link with more text')]),
+              text(' and '),
+              el('code', [text('some code')]),
+              text(' end.'),
+            ]),
+            el('li', [
+              el('em', [
+                text(
+                  'This entire item is emphasized and contains quite a lot of text to push the average up'
+                ),
+              ]),
+            ]),
+          ]),
+        ],
+      };
+
+      transform(tree, { threshold: 80 });
+
+      const ul = tree.children[0] as Element;
+      expect(ul.properties?.className).toContain('long-list-items');
+    });
+
+    it('works with ordered lists (ol)', () => {
+      const longText =
+        'This is a long ordered list item that should trigger the class application just like unordered lists do when averaging character counts.';
+      const tree: Root = {
+        type: 'root',
+        children: [el('ol', [li(longText), li(longText)])],
+      };
+
+      transform(tree);
+
+      const ol = tree.children[0] as Element;
+      expect(ol.properties?.className).toContain('long-list-items');
+    });
+  });
+});


### PR DESCRIPTION
Integrate rehype-list-density for improved spacing in lists based on item length. Update the styleguide to include a new section on list density, demonstrating the plugin's functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lists now receive automatic density-based spacing adjustments; text-heavy lists get a dedicated styling class.

* **Style**
  * Added a public CSS selector for long list items to enable targeted spacing rules.

* **Documentation**
  * Added a "Lists: Density-Based Spacing" example to the style guide.

* **Tests**
  * Added unit tests covering density detection, nested lists, thresholds, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->