### PR TITLE
Simplify Zod URL schema definitions

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,11 +21,7 @@ const articles = defineCollection({
         .enum(['medium', 'external'])
         .optional()
         .describe('For articles published elsewhere'),
-      redirectURL: z
-        .string()
-        .url()
-        .optional()
-        .describe('Redirect destination for external articles'),
+      redirectURL: z.url().optional().describe('Redirect destination for external articles'),
       styleguide: z.boolean().optional().describe('Styleguide page; excluded from RSS and indexes'),
     }),
 });
@@ -35,7 +31,7 @@ const notes = defineCollection({
   loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/notes' }),
   schema: z.object({
     title: z.string(),
-    sourceURL: z.string().url().optional().describe('Original URL for link posts'),
+    sourceURL: z.url().optional().describe('Original URL for link posts'),
     slug: z.string().optional().describe('Custom URL slug (defaults to filename)'),
     draft: z.boolean().default(false),
     description: z.string().optional(),
@@ -51,7 +47,7 @@ const toolboxPages = defineCollection({
   schema: z.object({
     id: z.string(),
     title: z.string(),
-    url: z.string().url(),
+    url: z.url(),
   }),
 });
 

--- a/src/styles/_verticalflow.css
+++ b/src/styles/_verticalflow.css
@@ -38,7 +38,25 @@
 
   .flow {
     /* Catch-all for elements not handled globally above */
-    & > * + *:not(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote, pre, figure, table, hr, [data-footnotes]) {
+    &
+      > *
+      + *:not(
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6,
+        p,
+        ul,
+        ol,
+        blockquote,
+        pre,
+        figure,
+        table,
+        hr,
+        [data-footnotes]
+      ) {
       margin-top: 1.25em;
     }
 

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -25,7 +25,7 @@ describe('Content Schema Logic', () => {
     });
 
     it('validates optional URL fields', () => {
-      const urlSchema = z.string().url().optional();
+      const urlSchema = z.url().optional();
       expect(() => urlSchema.parse('https://example.com')).not.toThrow();
       expect(() => urlSchema.parse(undefined)).not.toThrow();
       expect(() => urlSchema.parse('not-a-url')).toThrow();
@@ -69,7 +69,7 @@ describe('Content Schema Logic', () => {
         pubDate: z.coerce.date(),
         draft: z.boolean().default(false),
         styleguide: z.boolean().optional(),
-        sourceURL: z.string().url().optional(),
+        sourceURL: z.url().optional(),
       });
 
       const validNote = {


### PR DESCRIPTION
## Summary
Refactored URL schema definitions across the codebase to use Zod's `z.url()` method directly instead of the verbose `z.string().url()` pattern. This improves code readability and consistency while maintaining the same validation behavior.

## Changes
- **src/content.config.ts**: Simplified URL schema definitions in three collection schemas:
  - `articles` collection: `redirectURL` field
  - `notes` collection: `sourceURL` field
  - `toolboxPages` collection: `url` field
- **tests/unit/schemas.test.ts**: Updated test cases to reflect the simplified schema syntax
- **src/styles/_verticalflow.css**: Reformatted CSS selector for improved readability (multi-line formatting of the `:not()` pseudo-class selector)

## Implementation Details
The change from `z.string().url()` to `z.url()` is semantically equivalent—both validate that a value is a valid URL string. Using `z.url()` directly is more concise and is the recommended approach in Zod's API, reducing unnecessary method chaining while maintaining full validation parity.

https://claude.ai/code/session_011k6CT7keoY6qUkN5h7KgDv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated URL validation schemas across content collections for consistency
  * Reformatted CSS styling rules for improved readability

* **Tests**
  * Updated test schemas to align with validation changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dannysmith/dannyis-astro/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->