### PR TITLE
Wrap MDX tables in a focusable scroll region

### DIFF
--- a/src/components/mdx/WrappedTable.astro
+++ b/src/components/mdx/WrappedTable.astro
@@ -1,0 +1,32 @@
+---
+// Wraps every <table> in MDX content in a focusable scroll region so wide
+// tables don't blow out the page on narrow viewports. Wired up via
+// MDX_COMPONENT_REMAPPING in src/config/mdx-components.ts.
+//
+// Pattern via Adrian Roselli's "under-engineered responsive tables":
+// https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html
+---
+
+<div class="table-scroll" role="region" tabindex="0" aria-label="Scrollable table">
+  <table><slot /></table>
+</div>
+
+<style>
+  .table-scroll {
+    max-inline-size: 100%;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-gutter: stable;
+    /* Match the vertical rhythm of a bare <table> (see _verticalflow.css) */
+    margin-top: 1.25em;
+  }
+
+  .table-scroll:first-child {
+    margin-top: 0;
+  }
+
+  .table-scroll:focus-visible {
+    outline: var(--border-width-base) solid var(--color-accent);
+    outline-offset: var(--space-3xs);
+  }
+</style>

--- a/src/components/mdx/WrappedTable.astro
+++ b/src/components/mdx/WrappedTable.astro
@@ -5,10 +5,14 @@
 //
 // Pattern via Adrian Roselli's "under-engineered responsive tables":
 // https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html
+
+// Forward any attributes set on the original <table> (class, id, aria-*, etc.)
+// onto the rendered table so authors don't lose them through the remap.
+const props = Astro.props;
 ---
 
 <div class="table-scroll" role="region" tabindex="0" aria-label="Scrollable table">
-  <table><slot /></table>
+  <table {...props}><slot /></table>
 </div>
 
 <style>

--- a/src/config/mdx-components.ts
+++ b/src/config/mdx-components.ts
@@ -13,10 +13,12 @@ import SmartLink from '@components/mdx/SmartLink.astro';
 import BasicImage from '@components/mdx/BasicImage.astro';
 import MarkdownBlock from '@components/mdx/MarkdownBlock.astro';
 import FileTree from '@components/mdx/file-tree/FileTree.astro';
+import WrappedTable from '@components/mdx/WrappedTable.astro';
 
 export const MDX_COMPONENT_REMAPPING = {
   a: SmartLink,
   img: BasicImage,
+  table: WrappedTable,
   'markdown-preview': MarkdownBlock,
   'file-tree': FileTree,
 } as const;

--- a/src/pages/styleguide/_Typography.astro
+++ b/src/pages/styleguide/_Typography.astro
@@ -489,5 +489,60 @@ import { Content as ListDensityContent } from './_snippets/list-density.mdx';
         </tr>
       </tbody>
     </table>
+    <h2>Wide Tables</h2>
+    <p>
+      Tables wider than their container are wrapped in a focusable scroll region (<code
+        >div.table-scroll</code
+      >) and can be scrolled horizontally. Tables in MDX content get this wrapper automatically via
+      <code>MDX_COMPONENT_REMAPPING</code>; elsewhere, write the wrapper by hand.
+    </p>
+    <div class="table-scroll" role="region" tabindex="0" aria-label="Scrollable table">
+      <table>
+        <thead>
+          <tr>
+            <th>Quarter</th>
+            <th>Revenue</th>
+            <th>Expenses</th>
+            <th>Profit</th>
+            <th>Customers</th>
+            <th>Retention</th>
+            <th>NPS</th>
+            <th>Notes for the quarter</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Q1 2024</td>
+            <td>$124,500</td>
+            <td>$98,200</td>
+            <td>$26,300</td>
+            <td>1,204</td>
+            <td>92%</td>
+            <td>54</td>
+            <td>Steady growth driven by inbound leads.</td>
+          </tr>
+          <tr>
+            <td>Q2 2024</td>
+            <td>$156,800</td>
+            <td>$112,400</td>
+            <td>$44,400</td>
+            <td>1,488</td>
+            <td>94%</td>
+            <td>61</td>
+            <td>Launched the new pricing tiers mid-quarter.</td>
+          </tr>
+          <tr>
+            <td>Q3 2024</td>
+            <td>$189,200</td>
+            <td>$134,600</td>
+            <td>$54,600</td>
+            <td>1,712</td>
+            <td>93%</td>
+            <td>58</td>
+            <td>Slight churn uptick after the pricing change.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </SGTypographySwitcher>
 </section>

--- a/src/pages/styleguide/_Typography.astro
+++ b/src/pages/styleguide/_Typography.astro
@@ -11,6 +11,7 @@ import {
   highlight as Highlight,
   ResizableContainer,
 } from '@components/mdx/index';
+import WrappedTable from '@components/mdx/WrappedTable.astro';
 import { Content as ChecklistContent } from './_snippets/checklist.mdx';
 import { Content as ListDensityContent } from './_snippets/list-density.mdx';
 ---
@@ -496,53 +497,51 @@ import { Content as ListDensityContent } from './_snippets/list-density.mdx';
       >) and can be scrolled horizontally. Tables in MDX content get this wrapper automatically via
       <code>MDX_COMPONENT_REMAPPING</code>; elsewhere, write the wrapper by hand.
     </p>
-    <div class="table-scroll" role="region" tabindex="0" aria-label="Scrollable table">
-      <table>
-        <thead>
-          <tr>
-            <th>Quarter</th>
-            <th>Revenue</th>
-            <th>Expenses</th>
-            <th>Profit</th>
-            <th>Customers</th>
-            <th>Retention</th>
-            <th>NPS</th>
-            <th>Notes for the quarter</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Q1 2024</td>
-            <td>$124,500</td>
-            <td>$98,200</td>
-            <td>$26,300</td>
-            <td>1,204</td>
-            <td>92%</td>
-            <td>54</td>
-            <td>Steady growth driven by inbound leads.</td>
-          </tr>
-          <tr>
-            <td>Q2 2024</td>
-            <td>$156,800</td>
-            <td>$112,400</td>
-            <td>$44,400</td>
-            <td>1,488</td>
-            <td>94%</td>
-            <td>61</td>
-            <td>Launched the new pricing tiers mid-quarter.</td>
-          </tr>
-          <tr>
-            <td>Q3 2024</td>
-            <td>$189,200</td>
-            <td>$134,600</td>
-            <td>$54,600</td>
-            <td>1,712</td>
-            <td>93%</td>
-            <td>58</td>
-            <td>Slight churn uptick after the pricing change.</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+    <WrappedTable>
+      <thead>
+        <tr>
+          <th>Quarter</th>
+          <th>Revenue</th>
+          <th>Expenses</th>
+          <th>Profit</th>
+          <th>Customers</th>
+          <th>Retention</th>
+          <th>NPS</th>
+          <th>Notes for the quarter</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Q1 2024</td>
+          <td>$124,500</td>
+          <td>$98,200</td>
+          <td>$26,300</td>
+          <td>1,204</td>
+          <td>92%</td>
+          <td>54</td>
+          <td>Steady growth driven by inbound leads.</td>
+        </tr>
+        <tr>
+          <td>Q2 2024</td>
+          <td>$156,800</td>
+          <td>$112,400</td>
+          <td>$44,400</td>
+          <td>1,488</td>
+          <td>94%</td>
+          <td>61</td>
+          <td>Launched the new pricing tiers mid-quarter.</td>
+        </tr>
+        <tr>
+          <td>Q3 2024</td>
+          <td>$189,200</td>
+          <td>$134,600</td>
+          <td>$54,600</td>
+          <td>1,712</td>
+          <td>93%</td>
+          <td>58</td>
+          <td>Slight churn uptick after the pricing change.</td>
+        </tr>
+      </tbody>
+    </WrappedTable>
   </SGTypographySwitcher>
 </section>


### PR DESCRIPTION
## Summary

- Wide tables (e.g. the LCVid props table in [*Some Work on this Site*](/writing/2026-05-28-work-on-this-site/)) were blowing out the page on narrow viewports, forcing horizontal scroll on the whole document.
- Adds a small `WrappedTable.astro` component that wraps every `<table>` in `<div class="table-scroll" role="region" tabindex="0" aria-label="Scrollable table">` with `overflow-x: auto`.
- Wires it into the existing `MDX_COMPONENT_REMAPPING` so it applies automatically to every `<table>` in MDX content (both markdown-syntax tables and literal `<table>` HTML in `.mdx`). No per-file imports needed, no rehype plugin needed.
- Pattern follows Adrian Roselli's [Under-Engineered Responsive Tables](https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html) — keeps `<table>` semantics intact, focusable for keyboard users, announced as a region by screen readers.
- Adds a wide-table example to the Typography styleguide so the pattern is documented for future reference.

### Why component remap, not a rehype plugin

The codebase already has a `MDX_COMPONENT_REMAPPING` mechanism passed to `<Content components={...} />` for both articles and notes. Adding `table: WrappedTable` to it is a one-line change that uses an existing pattern, vs. introducing a new build-time plugin.

### Vertical rhythm note

`_verticalflow.css` targets bare `<table>` for top margin. With the wrapper, that selector no longer matches the grid child, so the same `margin-top: 1.25em` is applied to `.table-scroll` directly in the component. Kept local to the component rather than spreading the concern into `_verticalflow.css`.

## Test plan

- [x] `bun run check:types` passes
- [x] `bun run check:format` passes
- [x] `bun run check:lint` passes
- [x] Verified wrapper renders correctly in the styleguide (`/styleguide/#tables` → "Wide Tables" section)
- [ ] **Verify in browser on mobile viewport:** wide table scrolls horizontally without scrolling the page
- [ ] Verify focus outline is visible when tabbing into a wrapped table
- [ ] Verify both light and dark mode look right
- [ ] Verify the LCVid props table at `/writing/2026-05-28-work-on-this-site/` no longer overflows the page on mobile (couldn't test in sandbox — `<LCVid>` needs network access to `v.danny.is` which isn't available)

https://claude.ai/code/session_01UK75SrGWAYmuvYKBABuYb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UK75SrGWAYmuvYKBABuYb8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tables wider than the viewport now automatically become horizontally scrollable, improving usability across all screen sizes.
  * Enhanced keyboard accessibility for tables with visible focus indicators when navigating with a keyboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dannysmith/dannyis-astro/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->